### PR TITLE
feat: GET /point/:id/histories 구현

### DIFF
--- a/src/point/point.controller.ts
+++ b/src/point/point.controller.ts
@@ -23,9 +23,13 @@ export class PointController {
 
   @Get(':id')
   async point(@Param('id', ParsePositiveIntPipe) id: number): Promise<UserPoint> {
-    const userPoint = await this.userDb.selectById(id).catch(() => {
+    let userPoint: UserPoint;
+
+    try {
+userPoint = await this.userDb.selectById(id);
+    } catch (error) {
       throw new InternalServerErrorException();
-    });
+    }
 
     if (userPoint.point < 0 || userPoint.point > 10_000_000) {
       throw new InternalServerErrorException();

--- a/src/point/point.controller.ts
+++ b/src/point/point.controller.ts
@@ -26,7 +26,7 @@ export class PointController {
     let userPoint: UserPoint;
 
     try {
-userPoint = await this.userDb.selectById(id);
+      userPoint = await this.userDb.selectById(id);
     } catch (error) {
       throw new InternalServerErrorException();
     }
@@ -38,13 +38,18 @@ userPoint = await this.userDb.selectById(id);
     return userPoint;
   }
 
-  /**
-   * TODO - 특정 유저의 포인트 충전/이용 내역을 조회하는 기능을 작성해주세요.
-   */
   @Get(':id/histories')
-  async history(@Param('id') id): Promise<PointHistory[]> {
-    const userId = Number.parseInt(id);
-    return [];
+  async history(@Param('id', ParsePositiveIntPipe) id: number): Promise<PointHistory[]> {
+    let histories: PointHistory[];
+    try {
+      histories = await this.historyDb.selectAllByUserId(id);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
+
+    histories.sort((a, b) => b.timeMillis - a.timeMillis);
+
+    return histories;
   }
 
   /**


### PR DESCRIPTION
### 💬 배경

- 포인트 충전 내역을 반환하는 histories 엔드포인트를 구현합니다.

### 📚 커밋 로그

- .catch => try catch 리팩토링 : [49bae1c](https://github.com/seho0808/hh-9-be/pull/5/commits/49bae1cee2bbe5773cd350bf017660a17a1723a2)
- 테스트: [d8352ac](https://github.com/seho0808/hh-9-be/pull/5/commits/d8352acf10ee04662610abf6182c8e49894a8a4c)
- 구현: [1f72f3d](https://github.com/seho0808/hh-9-be/pull/5/commits/1f72f3dabf33d5e895360e6043f53000cc17f8e3)

### 🚧 참고 사항

- 포인트 기록의 요구사항 중 하나는 "`:id`로 주어진 유저만의 데이터를 반환해야한다"가 존재합니다.
- 해당 로직에 대한 케이스들을 테스팅하려면 db 레포지토리 레이어에 유닛 테스트를 하는 것이 맞아보입니다만, 지금 프로젝트 구조상 그것이 어려운 편입니다. 
- 신뢰성 높은 실제 db 였다면 검증이 엄격하게 필요한 케이스는 아니긴합니다. (테스트 효용성 낮음.)