### PR TITLE
feat: PATCH /points/:id/charge 구현

### DIFF
--- a/src/point/point.controller.spec.ts
+++ b/src/point/point.controller.spec.ts
@@ -172,4 +172,101 @@ describe('PointController', () => {
       });
     });
   });
+
+  describe('PATCH /point/:id/charge', () => {
+    describe('😊 정상 작동 (Happy Path & Passing Edge Cases)', () => {
+      it('포인트가 정상적으로 충전됨', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 100,
+          updateMillis: 123456789,
+        });
+        jest.spyOn(Date, 'now').mockReturnValue(123456789);
+
+        await controller.charge(1, { amount: 100 });
+
+        expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(1, 200);
+
+        expect(pointHistoryTable.insert).toHaveBeenCalledWith(
+          1,
+          100,
+          TransactionType.CHARGE,
+          123456789,
+        );
+      });
+
+      it('최소 충전 금액이 정상적으로 충전됨', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 100,
+          updateMillis: 123456789,
+        });
+        jest.spyOn(Date, 'now').mockReturnValue(123456789);
+
+        await controller.charge(1, { amount: 1 });
+
+        expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(1, 101);
+
+        expect(pointHistoryTable.insert).toHaveBeenCalledWith(
+          1,
+          1,
+          TransactionType.CHARGE,
+          123456789,
+        );
+      });
+
+      it('최대 충전 금액이 정상적으로 충전됨', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 0,
+          updateMillis: 123456789,
+        });
+        jest.spyOn(Date, 'now').mockReturnValue(123456789);
+
+        await controller.charge(1, { amount: 10_000_000 });
+
+        expect(pointHistoryTable.insert).toHaveBeenCalledWith(
+          1,
+          10_000_000,
+          TransactionType.CHARGE,
+          123456789,
+        );
+
+        expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(1, 10_000_000);
+      });
+    });
+
+    describe('💼 정책 예외 (Business Rule Violation)', () => {
+      it('충전 후 총 포인트가 10,000,000P 초과 시 400 에러 발생', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 10_000_000,
+          updateMillis: 123456789,
+        });
+
+        await expect(controller.charge(1, { amount: 1 })).rejects.toThrow(
+          BadRequestException,
+        );
+      });
+
+      it('포인트가 최소 충전 가능 포인트보다 작을 경우 400 에러 발생', async () => {
+        await expect(controller.charge(1, { amount: -1 })).rejects.toThrow(
+          BadRequestException,
+        );
+        await expect(controller.charge(1, { amount: 0 })).rejects.toThrow(
+          BadRequestException,
+        );
+      });
+    });
+
+    describe('💥 시스템 예외 (Unexpected Errors)', () => {
+      it('DB에서 예외가 발생하면 InternalServerError 발생', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockRejectedValue(new Error('DB error'));
+
+        await expect(controller.charge(1, { amount: 100 })).rejects.toThrow(
+          InternalServerErrorException,
+        );
+      });
+    });
+  });
 });


### PR DESCRIPTION
### 💬 배경

- 포인트를 충전하는 charge 엔드포인트를 구현합니다.

### 📚 커밋 로그

- 테스트 : [b1fc87e](https://github.com/seho0808/hh-9-be/pull/6/commits/b1fc87e7773ba2f21f5658967df04e3e74709f61)
- 구현: [0f4067b](https://github.com/seho0808/hh-9-be/pull/6/commits/0f4067be7300d27eca997525a759d848b483dde1)

### 🤔 고민 사항

- 이번에는 비즈니스 로직이 커지고 있어서 서비스 레이어가 따로 있는 것이 조금 더 깔끔해보였음. 어차피 추후 전체 리팩토링 예정.
- 엔티티 필드의 조건값이 엔티티에서 정의되는 것과 서비스 레이어에서 정의되는 것 어떤 것이 더 맞는지 어려운듯함.
  - 실세계를 상상해보았을 때 특정 엔티티가 여러 비즈니스 유스케이스에 사용되는 경우가 분명 많을 것이다.
  - 그렇기에 비즈니스 유스케이스 여러군데에서 다양하게 사용될 것 같으면 최대한 엔티티에서는 조건을 걸지 않고 열어두는 것이 좋을듯.

