### PR TITLE
refactor: 거대 컨트롤러를 여러 계층으로 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+coverage

--- a/src/point/point.controller.spec.ts
+++ b/src/point/point.controller.spec.ts
@@ -1,14 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PointController } from './point.controller';
-import { UserPointTable } from '../database/userpoint.table';
-import { PointHistoryTable } from '../database/pointhistory.table';
+import { PointService } from './point.service';
 import { BadRequestException, InternalServerErrorException } from '@nestjs/common';
 import { TransactionType } from './point.model';
 
 describe('PointController', () => {
   let controller: PointController;
-  let userPointTable: UserPointTable;
-  let pointHistoryTable: PointHistoryTable;
+  let pointService: PointService;
 
   beforeEach(async () => {
     jest.restoreAllMocks();
@@ -16,401 +14,120 @@ describe('PointController', () => {
       controllers: [PointController],
       providers: [
         {
-          provide: UserPointTable,
+          provide: PointService,
           useValue: {
-            selectById: jest.fn(),
-            insertOrUpdate: jest.fn(),
-          },
-        },
-        {
-          provide: PointHistoryTable,
-          useValue: {
-            insert: jest.fn(),
-            selectAllByUserId: jest.fn(),
+            getPoint: jest.fn(),
+            getHistory: jest.fn(),
+            chargePoint: jest.fn(),
+            usePoint: jest.fn(),
           },
         },
       ],
     }).compile();
 
     controller = module.get<PointController>(PointController);
-    userPointTable = module.get<UserPointTable>(UserPointTable);
-    pointHistoryTable = module.get<PointHistoryTable>(PointHistoryTable);
+    pointService = module.get<PointService>(PointService);
   });
 
   describe('GET /point/:id', () => {
-    describe('😊 정상 작동 (Happy Path & Passing Edge Cases)', () => {
-      it('포인트가 100일 경우 정상적으로 반환됨', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
-          id: 1,
-          point: 100,
-          updateMillis: 123456789,
-        });
+    it('서비스의 getPoint 메서드를 호출하고 결과를 반환함', async () => {
+      const mockResult = {
+        id: 1,
+        point: 100,
+        updateMillis: 123456789,
+      };
+      jest.spyOn(pointService, 'getPoint').mockResolvedValue(mockResult);
 
-        const result = await controller.point(1);
+      const result = await controller.point(1);
 
-        expect(result).toEqual({
-          id: 1,
-          point: 100,
-          updateMillis: 123456789,
-        });
-      });
-
-      it('포인트가 0일 경우에도 정상 반환됨', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
-          id: 1,
-          point: 0,
-          updateMillis: 123456789,
-        });
-
-        const result = await controller.point(1);
-
-        expect(result).toEqual({
-          id: 1,
-          point: 0,
-          updateMillis: 123456789,
-        });
-      });
-
-      it('포인트가 최대 허용값(10,000,000)일 때도 정상 반환됨', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
-          id: 1,
-          point: 10_000_000,
-          updateMillis: 123456789,
-        });
-
-        const result = await controller.point(1);
-
-        expect(result).toEqual({
-          id: 1,
-          point: 10_000_000,
-          updateMillis: 123456789,
-        });
-      });
+      expect(pointService.getPoint).toHaveBeenCalledWith(1);
+      expect(result).toEqual(mockResult);
     });
 
-    describe('💼 정책 예외 (Business Rule Violation)', () => {
-      it('포인트가 음수일 경우 500 에러 발생', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
-          id: 1,
-          point: -1,
-          updateMillis: 123456789,
-        });
+    it('서비스에서 예외가 발생하면 그대로 전파됨', async () => {
+      jest
+        .spyOn(pointService, 'getPoint')
+        .mockRejectedValue(new InternalServerErrorException());
 
-        await expect(controller.point(1)).rejects.toThrow(InternalServerErrorException);
-      });
-
-      it('포인트가 최대 허용값 초과 시 500 에러 발생', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
-          id: 1,
-          point: 10_000_001,
-          updateMillis: 123456789,
-        });
-
-        await expect(controller.point(1)).rejects.toThrow(InternalServerErrorException);
-      });
-    });
-
-    describe('💥 시스템 예외 (Unexpected Errors)', () => {
-      it('DB에서 예외가 발생하면 InternalServerError 발생', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockRejectedValue(new Error('DB error'));
-
-        await expect(controller.point(1)).rejects.toThrow(InternalServerErrorException);
-      });
+      await expect(controller.point(1)).rejects.toThrow(InternalServerErrorException);
     });
   });
 
   describe('GET /point/:id/histories', () => {
-    describe('😊 정상 작동 (Happy Path & Passing Edge Cases)', () => {
-      it('포인트 내역이 정상적으로 반환됨', async () => {
-        const mockedPointHistory = {
+    it('서비스의 getHistory 메서드를 호출하고 결과를 반환함', async () => {
+      const mockResult = [
+        {
           id: 1,
           userId: 1,
           amount: 100,
           type: TransactionType.CHARGE,
           timeMillis: 123456789,
-        };
-        jest
-          .spyOn(pointHistoryTable, 'selectAllByUserId')
-          .mockResolvedValue([mockedPointHistory]);
+        },
+      ];
+      jest.spyOn(pointService, 'getHistory').mockResolvedValue(mockResult);
 
-        const result = await controller.history(1);
+      const result = await controller.history(1);
 
-        expect(result).toEqual([mockedPointHistory]);
-      });
-
-      it('포인트 내역이 최신순으로 정렬되어 반환됨', async () => {
-        const mockedPointHistory1 = {
-          id: 1,
-          userId: 1,
-          amount: 100,
-          type: TransactionType.CHARGE,
-          timeMillis: 123456788,
-        };
-        const mockedPointHistory2 = {
-          id: 2,
-          userId: 1,
-          amount: 100,
-          type: TransactionType.CHARGE,
-          timeMillis: 123456789,
-        };
-        jest
-          .spyOn(pointHistoryTable, 'selectAllByUserId')
-          .mockResolvedValue([mockedPointHistory1, mockedPointHistory2]);
-
-        const result = await controller.history(1);
-
-        expect(result).toEqual([mockedPointHistory2, mockedPointHistory1]);
-      });
+      expect(pointService.getHistory).toHaveBeenCalledWith(1);
+      expect(result).toEqual(mockResult);
     });
 
-    describe('💥 시스템 예외 (Unexpected Errors)', () => {
-      it('DB에서 예외가 발생하면 InternalServerError 발생', async () => {
-        jest
-          .spyOn(pointHistoryTable, 'selectAllByUserId')
-          .mockRejectedValue(new Error('DB error'));
+    it('서비스에서 예외가 발생하면 그대로 전파됨', async () => {
+      jest
+        .spyOn(pointService, 'getHistory')
+        .mockRejectedValue(new InternalServerErrorException());
 
-        await expect(controller.history(1)).rejects.toThrow(InternalServerErrorException);
-      });
+      await expect(controller.history(1)).rejects.toThrow(InternalServerErrorException);
     });
   });
 
   describe('PATCH /point/:id/charge', () => {
-    describe('😊 정상 작동 (Happy Path & Passing Edge Cases)', () => {
-      it('포인트가 정상적으로 충전됨', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
-          id: 1,
-          point: 100,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(Date, 'now').mockReturnValue(123456789);
+    it('서비스의 chargePoint 메서드를 호출하고 결과를 반환함', async () => {
+      const mockResult = {
+        id: 1,
+        point: 200,
+        updateMillis: 123456789,
+      };
+      jest.spyOn(pointService, 'chargePoint').mockResolvedValue(mockResult);
 
-        await controller.charge(1, { amount: 100 });
+      const result = await controller.charge(1, { amount: 100 });
 
-        expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(1, 200);
-
-        expect(pointHistoryTable.insert).toHaveBeenCalledWith(
-          1,
-          100,
-          TransactionType.CHARGE,
-          123456789,
-        );
-      });
-
-      it('최소 충전 금액이 정상적으로 충전됨', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
-          id: 1,
-          point: 100,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(Date, 'now').mockReturnValue(123456789);
-
-        await controller.charge(1, { amount: 1 });
-
-        expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(1, 101);
-
-        expect(pointHistoryTable.insert).toHaveBeenCalledWith(
-          1,
-          1,
-          TransactionType.CHARGE,
-          123456789,
-        );
-      });
-
-      it('최대 충전 금액이 정상적으로 충전됨', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
-          id: 1,
-          point: 0,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(Date, 'now').mockReturnValue(123456789);
-
-        await controller.charge(1, { amount: 10_000_000 });
-
-        expect(pointHistoryTable.insert).toHaveBeenCalledWith(
-          1,
-          10_000_000,
-          TransactionType.CHARGE,
-          123456789,
-        );
-
-        expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(1, 10_000_000);
-      });
+      expect(pointService.chargePoint).toHaveBeenCalledWith(1, 100);
+      expect(result).toEqual(mockResult);
     });
 
-    describe('💼 정책 예외 (Business Rule Violation)', () => {
-      it('충전 후 총 포인트가 10,000,000P 초과 시 400 에러 발생', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
-          id: 1,
-          point: 10_000_000,
-          updateMillis: 123456789,
-        });
+    it('서비스에서 예외가 발생하면 그대로 전파됨', async () => {
+      jest
+        .spyOn(pointService, 'chargePoint')
+        .mockRejectedValue(new BadRequestException());
 
-        await expect(controller.charge(1, { amount: 1 })).rejects.toThrow(
-          BadRequestException,
-        );
-      });
-
-      it('포인트가 최소 충전 가능 포인트보다 작을 경우 400 에러 발생', async () => {
-        await expect(controller.charge(1, { amount: -1 })).rejects.toThrow(
-          BadRequestException,
-        );
-        await expect(controller.charge(1, { amount: 0 })).rejects.toThrow(
-          BadRequestException,
-        );
-      });
-    });
-
-    describe('💥 시스템 예외 (Unexpected Errors)', () => {
-      it('DB에서 예외가 발생하면 InternalServerError 발생', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockRejectedValue(new Error('DB error'));
-
-        await expect(controller.charge(1, { amount: 100 })).rejects.toThrow(
-          InternalServerErrorException,
-        );
-      });
+      await expect(controller.charge(1, { amount: 100 })).rejects.toThrow(
+        BadRequestException,
+      );
     });
   });
 
   describe('PATCH /point/:id/use', () => {
-    describe('😊 정상 작동 (Happy Path & Passing Edge Cases)', () => {
-      it('포인트가 정상적으로 사용됨', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
-          id: 1,
-          point: 1000,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(Date, 'now').mockReturnValue(123456789);
-        jest.spyOn(pointHistoryTable, 'selectAllByUserId').mockResolvedValue([]);
+    it('서비스의 usePoint 메서드를 호출하고 결과를 반환함', async () => {
+      const mockResult = {
+        id: 1,
+        point: 900,
+        updateMillis: 123456789,
+      };
+      jest.spyOn(pointService, 'usePoint').mockResolvedValue(mockResult);
 
-        await controller.use(1, { amount: 100 });
+      const result = await controller.use(1, { amount: 100 });
 
-        expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(1, 900);
-
-        expect(pointHistoryTable.insert).toHaveBeenCalledWith(
-          1,
-          100,
-          TransactionType.USE,
-          123456789,
-        );
-      });
-
-      it('최소 사용 단위(100P) 금액이 정상적으로 사용됨', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
-          id: 1,
-          point: 100,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(Date, 'now').mockReturnValue(123456789);
-        jest.spyOn(pointHistoryTable, 'selectAllByUserId').mockResolvedValue([]);
-
-        await controller.use(1, { amount: 100 });
-
-        expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(1, 0);
-
-        expect(pointHistoryTable.insert).toHaveBeenCalledWith(
-          1,
-          100,
-          TransactionType.USE,
-          123456789,
-        );
-      });
-
-      it('최대 사용 금액(10,000P)이 정상적으로 사용됨', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
-          id: 1,
-          point: 5_000_000,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(Date, 'now').mockReturnValue(123456789);
-        jest.spyOn(pointHistoryTable, 'selectAllByUserId').mockResolvedValue([]);
-
-        await controller.use(1, { amount: 10_000 });
-
-        expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(1, 4_990_000);
-
-        expect(pointHistoryTable.insert).toHaveBeenCalledWith(
-          1,
-          10_000,
-          TransactionType.USE,
-          123456789,
-        );
-      });
+      expect(pointService.usePoint).toHaveBeenCalledWith(1, 100);
+      expect(result).toEqual(mockResult);
     });
 
-    describe('💼 정책 예외 (Business Rule Violation)', () => {
-      it('포인트가 최소 사용 단위(100P)보다 작을 경우 400 에러 발생', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
-          id: 1,
-          point: 1000,
-          updateMillis: 123456789,
-        });
+    it('서비스에서 예외가 발생하면 그대로 전파됨', async () => {
+      jest.spyOn(pointService, 'usePoint').mockRejectedValue(new BadRequestException());
 
-        await expect(controller.use(1, { amount: 99 })).rejects.toThrow(
-          BadRequestException,
-        );
-        await expect(controller.use(1, { amount: 0 })).rejects.toThrow(
-          BadRequestException,
-        );
-        await expect(controller.use(1, { amount: -1 })).rejects.toThrow(
-          BadRequestException,
-        );
-        await expect(controller.use(1, { amount: 101 })).rejects.toThrow(
-          BadRequestException,
-        );
-      });
-
-      it('포인트 사용 후 포인트가 음수가 될 경우 400 에러 발생', async () => {
-        jest.spyOn(pointHistoryTable, 'selectAllByUserId').mockResolvedValue([]);
-        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
-          id: 1,
-          point: 100,
-          updateMillis: 123456789,
-        });
-
-        await expect(controller.use(1, { amount: 200 })).rejects.toThrow(
-          BadRequestException,
-        );
-      });
-
-      it('하루 최대 사용 가능 포인트를 초과할 경우 400 에러 발생', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
-          id: 1,
-          point: 100000,
-          updateMillis: 123456789,
-        });
-
-        jest.spyOn(pointHistoryTable, 'selectAllByUserId').mockResolvedValue([
-          {
-            id: 1,
-            userId: 1,
-            amount: 30000,
-            type: TransactionType.USE,
-            timeMillis: Date.now(),
-          },
-          {
-            id: 2,
-            userId: 1,
-            amount: 20000,
-            type: TransactionType.USE,
-            timeMillis: Date.now(),
-          },
-        ]);
-
-        // 이미 50000P를 사용했으므로 추가 사용 불가
-        await expect(controller.use(1, { amount: 100 })).rejects.toThrow(
-          BadRequestException,
-        );
-      });
-    });
-
-    describe('💥 시스템 예외 (Unexpected Errors)', () => {
-      it('DB에서 예외가 발생하면 InternalServerError 발생', async () => {
-        jest.spyOn(userPointTable, 'selectById').mockRejectedValue(new Error('DB error'));
-
-        await expect(controller.use(1, { amount: 100 })).rejects.toThrow(
-          InternalServerErrorException,
-        );
-      });
+      await expect(controller.use(1, { amount: 100 })).rejects.toThrow(
+        BadRequestException,
+      );
     });
   });
 });

--- a/src/point/point.controller.ts
+++ b/src/point/point.controller.ts
@@ -1,55 +1,21 @@
-import {
-  BadRequestException,
-  Body,
-  Controller,
-  Get,
-  InternalServerErrorException,
-  Param,
-  Patch,
-  ValidationPipe,
-} from '@nestjs/common';
-import { PointHistory, TransactionType, UserPoint } from './point.model';
-import { UserPointTable } from 'src/database/userpoint.table';
-import { PointHistoryTable } from 'src/database/pointhistory.table';
+import { Body, Controller, Get, Param, Patch, ValidationPipe } from '@nestjs/common';
+import { PointHistory, UserPoint } from './point.model';
 import { PointBody as PointDto } from './point.dto';
 import { ParsePositiveIntPipe } from 'src/common/pipes/parse-positive-int.pipe';
+import { PointService } from './point.service';
 
 @Controller('/point')
 export class PointController {
-  constructor(
-    private readonly userDb: UserPointTable,
-    private readonly historyDb: PointHistoryTable,
-  ) {}
+  constructor(private readonly pointService: PointService) {}
 
   @Get(':id')
   async point(@Param('id', ParsePositiveIntPipe) id: number): Promise<UserPoint> {
-    let userPoint: UserPoint;
-
-    try {
-      userPoint = await this.userDb.selectById(id);
-    } catch (error) {
-      throw new InternalServerErrorException();
-    }
-
-    if (userPoint.point < 0 || userPoint.point > 10_000_000) {
-      throw new InternalServerErrorException();
-    }
-
-    return userPoint;
+    return this.pointService.getPoint(id);
   }
 
   @Get(':id/histories')
   async history(@Param('id', ParsePositiveIntPipe) id: number): Promise<PointHistory[]> {
-    let histories: PointHistory[];
-    try {
-      histories = await this.historyDb.selectAllByUserId(id);
-    } catch (error) {
-      throw new InternalServerErrorException();
-    }
-
-    histories.sort((a, b) => b.timeMillis - a.timeMillis);
-
-    return histories;
+    return this.pointService.getHistory(id);
   }
 
   @Patch(':id/charge')
@@ -57,36 +23,7 @@ export class PointController {
     @Param('id', ParsePositiveIntPipe) id: number,
     @Body(ValidationPipe) pointDto: PointDto,
   ): Promise<UserPoint> {
-    // TODO: 추후 서비스 레이어로 리팩토링 시 여러개의 함수로 분리해야 함
-    const amount = pointDto.amount;
-    if (amount < 1 || amount > 10_000_000) {
-      throw new BadRequestException();
-    }
-
-    let currentPoint: UserPoint;
-
-    try {
-      currentPoint = await this.userDb.selectById(id);
-    } catch (error) {
-      throw new InternalServerErrorException();
-    }
-
-    const newPoint = currentPoint.point + amount;
-
-    if (newPoint > 10_000_000) {
-      throw new BadRequestException();
-    }
-
-    let updatedPoint: UserPoint;
-
-    try {
-      updatedPoint = await this.userDb.insertOrUpdate(id, newPoint);
-      await this.historyDb.insert(id, amount, TransactionType.CHARGE, Date.now());
-    } catch (error) {
-      throw new InternalServerErrorException();
-    }
-
-    return updatedPoint;
+    return this.pointService.chargePoint(id, pointDto.amount);
   }
 
   @Patch(':id/use')
@@ -94,50 +31,6 @@ export class PointController {
     @Param('id', ParsePositiveIntPipe) id: number,
     @Body(ValidationPipe) pointDto: PointDto,
   ): Promise<UserPoint> {
-    // TODO: 추후 서비스 레이어로 리팩토링 시 여러개의 함수로 분리해야 함
-    const amount = pointDto.amount;
-    if (amount < 100 || amount > 10_000_000 || amount % 100 !== 0) {
-      throw new BadRequestException();
-    }
-
-    let currentPoint: UserPoint;
-    let histories: PointHistory[];
-
-    try {
-      currentPoint = await this.userDb.selectById(id);
-      histories = await this.historyDb.selectAllByUserId(id);
-    } catch (error) {
-      throw new InternalServerErrorException();
-    }
-
-    const pointsUsedToday = histories
-      .filter(
-        history =>
-          history.type === TransactionType.USE &&
-          history.timeMillis > Date.now() - 24 * 60 * 60 * 1000,
-      )
-      .reduce((acc, history) => acc + history.amount, 0);
-    const newPointsUsedToday = pointsUsedToday + amount;
-
-    if (newPointsUsedToday > 50000) {
-      throw new BadRequestException();
-    }
-
-    const newPoint = currentPoint.point - amount;
-
-    if (newPoint < 0) {
-      throw new BadRequestException();
-    }
-
-    let updatedPoint: UserPoint;
-
-    try {
-      updatedPoint = await this.userDb.insertOrUpdate(id, newPoint);
-      await this.historyDb.insert(id, amount, TransactionType.USE, Date.now());
-    } catch (error) {
-      throw new InternalServerErrorException();
-    }
-
-    return updatedPoint;
+    return this.pointService.usePoint(id, pointDto.amount);
   }
 }

--- a/src/point/point.module.ts
+++ b/src/point/point.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { PointController } from './point.controller';
+import { PointService } from './point.service';
 import { DatabaseModule } from 'src/database/database.module';
 
 @Module({
   imports: [DatabaseModule],
   controllers: [PointController],
+  providers: [PointService],
 })
 export class PointModule {}

--- a/src/point/point.module.ts
+++ b/src/point/point.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { PointController } from './point.controller';
 import { PointService } from './point.service';
 import { DatabaseModule } from 'src/database/database.module';
+import { PointPolicy } from './policy/point.policy';
+import { PointRepository } from './repository/point.repository';
 
 @Module({
   imports: [DatabaseModule],
   controllers: [PointController],
-  providers: [PointService],
+  providers: [PointService, PointPolicy, PointRepository],
 })
 export class PointModule {}

--- a/src/point/point.service.spec.ts
+++ b/src/point/point.service.spec.ts
@@ -1,0 +1,398 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PointService } from './point.service';
+import { UserPointTable } from '../database/userpoint.table';
+import { PointHistoryTable } from '../database/pointhistory.table';
+import { BadRequestException, InternalServerErrorException } from '@nestjs/common';
+import { TransactionType } from './point.model';
+
+describe('PointService', () => {
+  let service: PointService;
+  let userPointTable: UserPointTable;
+  let pointHistoryTable: PointHistoryTable;
+
+  beforeEach(async () => {
+    jest.restoreAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PointService,
+        {
+          provide: UserPointTable,
+          useValue: {
+            selectById: jest.fn(),
+            insertOrUpdate: jest.fn(),
+          },
+        },
+        {
+          provide: PointHistoryTable,
+          useValue: {
+            insert: jest.fn(),
+            selectAllByUserId: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<PointService>(PointService);
+    userPointTable = module.get<UserPointTable>(UserPointTable);
+    pointHistoryTable = module.get<PointHistoryTable>(PointHistoryTable);
+  });
+
+  describe('getPoint', () => {
+    describe('😊 정상 작동 (Happy Path & Passing Edge Cases)', () => {
+      it('포인트가 100일 경우 정상적으로 반환됨', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 100,
+          updateMillis: 123456789,
+        });
+
+        const result = await service.getPoint(1);
+
+        expect(result).toEqual({
+          id: 1,
+          point: 100,
+          updateMillis: 123456789,
+        });
+      });
+
+      it('포인트가 0일 경우에도 정상 반환됨', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 0,
+          updateMillis: 123456789,
+        });
+
+        const result = await service.getPoint(1);
+
+        expect(result).toEqual({
+          id: 1,
+          point: 0,
+          updateMillis: 123456789,
+        });
+      });
+
+      it('포인트가 최대 허용값(10,000,000)일 때도 정상 반환됨', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 10_000_000,
+          updateMillis: 123456789,
+        });
+
+        const result = await service.getPoint(1);
+
+        expect(result).toEqual({
+          id: 1,
+          point: 10_000_000,
+          updateMillis: 123456789,
+        });
+      });
+    });
+
+    describe('💼 정책 예외 (Business Rule Violation)', () => {
+      it('포인트가 음수일 경우 500 에러 발생', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: -1,
+          updateMillis: 123456789,
+        });
+
+        await expect(service.getPoint(1)).rejects.toThrow(InternalServerErrorException);
+      });
+
+      it('포인트가 최대 허용값 초과 시 500 에러 발생', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 10_000_001,
+          updateMillis: 123456789,
+        });
+
+        await expect(service.getPoint(1)).rejects.toThrow(InternalServerErrorException);
+      });
+    });
+
+    describe('💥 시스템 예외 (Unexpected Errors)', () => {
+      it('DB에서 예외가 발생하면 InternalServerError 발생', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockRejectedValue(new Error('DB error'));
+
+        await expect(service.getPoint(1)).rejects.toThrow(InternalServerErrorException);
+      });
+    });
+  });
+
+  describe('getHistory', () => {
+    describe('😊 정상 작동 (Happy Path & Passing Edge Cases)', () => {
+      it('포인트 내역이 정상적으로 반환됨', async () => {
+        const mockedPointHistory = {
+          id: 1,
+          userId: 1,
+          amount: 100,
+          type: TransactionType.CHARGE,
+          timeMillis: 123456789,
+        };
+        jest
+          .spyOn(pointHistoryTable, 'selectAllByUserId')
+          .mockResolvedValue([mockedPointHistory]);
+
+        const result = await service.getHistory(1);
+
+        expect(result).toEqual([mockedPointHistory]);
+      });
+
+      it('포인트 내역이 최신순으로 정렬되어 반환됨', async () => {
+        const mockedPointHistory1 = {
+          id: 1,
+          userId: 1,
+          amount: 100,
+          type: TransactionType.CHARGE,
+          timeMillis: 123456788,
+        };
+        const mockedPointHistory2 = {
+          id: 2,
+          userId: 1,
+          amount: 100,
+          type: TransactionType.CHARGE,
+          timeMillis: 123456789,
+        };
+        jest
+          .spyOn(pointHistoryTable, 'selectAllByUserId')
+          .mockResolvedValue([mockedPointHistory1, mockedPointHistory2]);
+
+        const result = await service.getHistory(1);
+
+        expect(result).toEqual([mockedPointHistory2, mockedPointHistory1]);
+      });
+    });
+
+    describe('💥 시스템 예외 (Unexpected Errors)', () => {
+      it('DB에서 예외가 발생하면 InternalServerError 발생', async () => {
+        jest
+          .spyOn(pointHistoryTable, 'selectAllByUserId')
+          .mockRejectedValue(new Error('DB error'));
+
+        await expect(service.getHistory(1)).rejects.toThrow(InternalServerErrorException);
+      });
+    });
+  });
+
+  describe('chargePoint', () => {
+    describe('😊 정상 작동 (Happy Path & Passing Edge Cases)', () => {
+      it('포인트가 정상적으로 충전됨', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 100,
+          updateMillis: 123456789,
+        });
+        jest.spyOn(Date, 'now').mockReturnValue(123456789);
+
+        await service.chargePoint(1, 100);
+
+        expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(1, 200);
+
+        expect(pointHistoryTable.insert).toHaveBeenCalledWith(
+          1,
+          100,
+          TransactionType.CHARGE,
+          123456789,
+        );
+      });
+
+      it('최소 충전 금액이 정상적으로 충전됨', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 100,
+          updateMillis: 123456789,
+        });
+        jest.spyOn(Date, 'now').mockReturnValue(123456789);
+
+        await service.chargePoint(1, 1);
+
+        expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(1, 101);
+
+        expect(pointHistoryTable.insert).toHaveBeenCalledWith(
+          1,
+          1,
+          TransactionType.CHARGE,
+          123456789,
+        );
+      });
+
+      it('최대 충전 금액이 정상적으로 충전됨', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 0,
+          updateMillis: 123456789,
+        });
+        jest.spyOn(Date, 'now').mockReturnValue(123456789);
+
+        await service.chargePoint(1, 10_000_000);
+
+        expect(pointHistoryTable.insert).toHaveBeenCalledWith(
+          1,
+          10_000_000,
+          TransactionType.CHARGE,
+          123456789,
+        );
+
+        expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(1, 10_000_000);
+      });
+    });
+
+    describe('💼 정책 예외 (Business Rule Violation)', () => {
+      it('충전 후 총 포인트가 10,000,000P 초과 시 400 에러 발생', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 10_000_000,
+          updateMillis: 123456789,
+        });
+
+        await expect(service.chargePoint(1, 1)).rejects.toThrow(BadRequestException);
+      });
+
+      it('포인트가 최소 충전 가능 포인트보다 작을 경우 400 에러 발생', async () => {
+        await expect(service.chargePoint(1, -1)).rejects.toThrow(BadRequestException);
+        await expect(service.chargePoint(1, 0)).rejects.toThrow(BadRequestException);
+      });
+    });
+
+    describe('💥 시스템 예외 (Unexpected Errors)', () => {
+      it('DB에서 예외가 발생하면 InternalServerError 발생', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockRejectedValue(new Error('DB error'));
+
+        await expect(service.chargePoint(1, 100)).rejects.toThrow(
+          InternalServerErrorException,
+        );
+      });
+    });
+  });
+
+  describe('usePoint', () => {
+    describe('😊 정상 작동 (Happy Path & Passing Edge Cases)', () => {
+      it('포인트가 정상적으로 사용됨', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 1000,
+          updateMillis: 123456789,
+        });
+        jest.spyOn(Date, 'now').mockReturnValue(123456789);
+        jest.spyOn(pointHistoryTable, 'selectAllByUserId').mockResolvedValue([]);
+
+        await service.usePoint(1, 100);
+
+        expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(1, 900);
+
+        expect(pointHistoryTable.insert).toHaveBeenCalledWith(
+          1,
+          100,
+          TransactionType.USE,
+          123456789,
+        );
+      });
+
+      it('최소 사용 단위(100P) 금액이 정상적으로 사용됨', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 100,
+          updateMillis: 123456789,
+        });
+        jest.spyOn(Date, 'now').mockReturnValue(123456789);
+        jest.spyOn(pointHistoryTable, 'selectAllByUserId').mockResolvedValue([]);
+
+        await service.usePoint(1, 100);
+
+        expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(1, 0);
+
+        expect(pointHistoryTable.insert).toHaveBeenCalledWith(
+          1,
+          100,
+          TransactionType.USE,
+          123456789,
+        );
+      });
+
+      it('최대 사용 금액(10,000P)이 정상적으로 사용됨', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 5_000_000,
+          updateMillis: 123456789,
+        });
+        jest.spyOn(Date, 'now').mockReturnValue(123456789);
+        jest.spyOn(pointHistoryTable, 'selectAllByUserId').mockResolvedValue([]);
+
+        await service.usePoint(1, 10_000);
+
+        expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(1, 4_990_000);
+
+        expect(pointHistoryTable.insert).toHaveBeenCalledWith(
+          1,
+          10_000,
+          TransactionType.USE,
+          123456789,
+        );
+      });
+    });
+
+    describe('💼 정책 예외 (Business Rule Violation)', () => {
+      it('포인트가 최소 사용 단위(100P)보다 작을 경우 400 에러 발생', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 1000,
+          updateMillis: 123456789,
+        });
+
+        await expect(service.usePoint(1, 99)).rejects.toThrow(BadRequestException);
+        await expect(service.usePoint(1, 0)).rejects.toThrow(BadRequestException);
+        await expect(service.usePoint(1, -1)).rejects.toThrow(BadRequestException);
+        await expect(service.usePoint(1, 101)).rejects.toThrow(BadRequestException);
+      });
+
+      it('포인트 사용 후 포인트가 음수가 될 경우 400 에러 발생', async () => {
+        jest.spyOn(pointHistoryTable, 'selectAllByUserId').mockResolvedValue([]);
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 100,
+          updateMillis: 123456789,
+        });
+
+        await expect(service.usePoint(1, 200)).rejects.toThrow(BadRequestException);
+      });
+
+      it('하루 최대 사용 가능 포인트를 초과할 경우 400 에러 발생', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockResolvedValue({
+          id: 1,
+          point: 100000,
+          updateMillis: 123456789,
+        });
+
+        jest.spyOn(pointHistoryTable, 'selectAllByUserId').mockResolvedValue([
+          {
+            id: 1,
+            userId: 1,
+            amount: 30000,
+            type: TransactionType.USE,
+            timeMillis: Date.now(),
+          },
+          {
+            id: 2,
+            userId: 1,
+            amount: 20000,
+            type: TransactionType.USE,
+            timeMillis: Date.now(),
+          },
+        ]);
+
+        // 이미 50000P를 사용했으므로 추가 사용 불가
+        await expect(service.usePoint(1, 100)).rejects.toThrow(BadRequestException);
+      });
+    });
+
+    describe('💥 시스템 예외 (Unexpected Errors)', () => {
+      it('DB에서 예외가 발생하면 InternalServerError 발생', async () => {
+        jest.spyOn(userPointTable, 'selectById').mockRejectedValue(new Error('DB error'));
+
+        await expect(service.usePoint(1, 100)).rejects.toThrow(
+          InternalServerErrorException,
+        );
+      });
+    });
+  });
+});

--- a/src/point/point.service.ts
+++ b/src/point/point.service.ts
@@ -1,0 +1,124 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { PointHistory, TransactionType, UserPoint } from './point.model';
+import { UserPointTable } from 'src/database/userpoint.table';
+import { PointHistoryTable } from 'src/database/pointhistory.table';
+
+@Injectable()
+export class PointService {
+  constructor(
+    private readonly userDb: UserPointTable,
+    private readonly historyDb: PointHistoryTable,
+  ) {}
+
+  async getPoint(id: number): Promise<UserPoint> {
+    let userPoint: UserPoint;
+
+    try {
+      userPoint = await this.userDb.selectById(id);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
+
+    if (userPoint.point < 0 || userPoint.point > 10_000_000) {
+      throw new InternalServerErrorException();
+    }
+
+    return userPoint;
+  }
+
+  async getHistory(id: number): Promise<PointHistory[]> {
+    let histories: PointHistory[];
+    try {
+      histories = await this.historyDb.selectAllByUserId(id);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
+
+    histories.sort((a, b) => b.timeMillis - a.timeMillis);
+
+    return histories;
+  }
+
+  // TODO: 함수 분리 리팩토링
+  async chargePoint(id: number, amount: number): Promise<UserPoint> {
+    if (amount < 1 || amount > 10_000_000) {
+      throw new BadRequestException();
+    }
+
+    let currentPoint: UserPoint;
+
+    try {
+      currentPoint = await this.userDb.selectById(id);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
+
+    const newPoint = currentPoint.point + amount;
+
+    if (newPoint > 10_000_000) {
+      throw new BadRequestException();
+    }
+
+    let updatedPoint: UserPoint;
+
+    try {
+      updatedPoint = await this.userDb.insertOrUpdate(id, newPoint);
+      await this.historyDb.insert(id, amount, TransactionType.CHARGE, Date.now());
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
+
+    return updatedPoint;
+  }
+
+  // TODO: 함수 분리 리팩토링
+  async usePoint(id: number, amount: number): Promise<UserPoint> {
+    if (amount < 100 || amount > 10_000_000 || amount % 100 !== 0) {
+      throw new BadRequestException();
+    }
+
+    let currentPoint: UserPoint;
+    let histories: PointHistory[];
+
+    try {
+      currentPoint = await this.userDb.selectById(id);
+      histories = await this.historyDb.selectAllByUserId(id);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
+
+    const pointsUsedToday = histories
+      .filter(
+        history =>
+          history.type === TransactionType.USE &&
+          history.timeMillis > Date.now() - 24 * 60 * 60 * 1000,
+      )
+      .reduce((acc, history) => acc + history.amount, 0);
+    const newPointsUsedToday = pointsUsedToday + amount;
+
+    if (newPointsUsedToday > 50000) {
+      throw new BadRequestException();
+    }
+
+    const newPoint = currentPoint.point - amount;
+
+    if (newPoint < 0) {
+      throw new BadRequestException();
+    }
+
+    let updatedPoint: UserPoint;
+
+    try {
+      updatedPoint = await this.userDb.insertOrUpdate(id, newPoint);
+      await this.historyDb.insert(id, amount, TransactionType.USE, Date.now());
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
+
+    return updatedPoint;
+  }
+}

--- a/src/point/point.service.ts
+++ b/src/point/point.service.ts
@@ -9,116 +9,138 @@ import { PointHistoryTable } from 'src/database/pointhistory.table';
 
 @Injectable()
 export class PointService {
+  private static readonly MAX_POINT_LIMIT = 10_000_000;
+  private static readonly DAILY_USE_LIMIT = 50_000;
+  private static readonly MIN_USE_AMOUNT = 100;
+  private static readonly USE_AMOUNT_UNIT = 100;
+
   constructor(
     private readonly userDb: UserPointTable,
     private readonly historyDb: PointHistoryTable,
   ) {}
 
   async getPoint(id: number): Promise<UserPoint> {
-    let userPoint: UserPoint;
-
-    try {
-      userPoint = await this.userDb.selectById(id);
-    } catch (error) {
-      throw new InternalServerErrorException();
-    }
-
-    if (userPoint.point < 0 || userPoint.point > 10_000_000) {
-      throw new InternalServerErrorException();
-    }
-
+    const userPoint = await this.getUserPointSafely(id);
+    this.validatePointRange(userPoint.point);
     return userPoint;
   }
 
   async getHistory(id: number): Promise<PointHistory[]> {
-    let histories: PointHistory[];
-    try {
-      histories = await this.historyDb.selectAllByUserId(id);
-    } catch (error) {
-      throw new InternalServerErrorException();
-    }
-
-    histories.sort((a, b) => b.timeMillis - a.timeMillis);
-
-    return histories;
+    const histories = await this.getHistoriesSafely(id);
+    return this.sortHistoriesByTimeDesc(histories);
   }
 
-  // TODO: 함수 분리 리팩토링
   async chargePoint(id: number, amount: number): Promise<UserPoint> {
-    if (amount < 1 || amount > 10_000_000) {
-      throw new BadRequestException();
-    }
+    this.validateChargeAmount(amount);
 
-    let currentPoint: UserPoint;
-
-    try {
-      currentPoint = await this.userDb.selectById(id);
-    } catch (error) {
-      throw new InternalServerErrorException();
-    }
+    const currentPoint = await this.getUserPointSafely(id);
+    this.validateChargeLimit(currentPoint.point, amount);
 
     const newPoint = currentPoint.point + amount;
-
-    if (newPoint > 10_000_000) {
-      throw new BadRequestException();
-    }
-
-    let updatedPoint: UserPoint;
-
-    try {
-      updatedPoint = await this.userDb.insertOrUpdate(id, newPoint);
-      await this.historyDb.insert(id, amount, TransactionType.CHARGE, Date.now());
-    } catch (error) {
-      throw new InternalServerErrorException();
-    }
-
-    return updatedPoint;
+    return await this.updatePointWithHistory(
+      id,
+      newPoint,
+      amount,
+      TransactionType.CHARGE,
+    );
   }
 
-  // TODO: 함수 분리 리팩토링
   async usePoint(id: number, amount: number): Promise<UserPoint> {
-    if (amount < 100 || amount > 10_000_000 || amount % 100 !== 0) {
-      throw new BadRequestException();
-    }
+    this.validateUseAmount(amount);
 
-    let currentPoint: UserPoint;
-    let histories: PointHistory[];
-
-    try {
-      currentPoint = await this.userDb.selectById(id);
-      histories = await this.historyDb.selectAllByUserId(id);
-    } catch (error) {
-      throw new InternalServerErrorException();
-    }
-
-    const pointsUsedToday = histories
-      .filter(
-        history =>
-          history.type === TransactionType.USE &&
-          history.timeMillis > Date.now() - 24 * 60 * 60 * 1000,
-      )
-      .reduce((acc, history) => acc + history.amount, 0);
-    const newPointsUsedToday = pointsUsedToday + amount;
-
-    if (newPointsUsedToday > 50000) {
-      throw new BadRequestException();
-    }
+    const currentPoint = await this.getUserPointSafely(id);
+    await this.validateDailyUseLimit(id, amount);
+    this.validateSufficientBalance(currentPoint.point, amount);
 
     const newPoint = currentPoint.point - amount;
+    return await this.updatePointWithHistory(id, newPoint, amount, TransactionType.USE);
+  }
 
-    if (newPoint < 0) {
+  private validatePointRange(point: number): void {
+    if (point < 0 || point > PointService.MAX_POINT_LIMIT) {
+      throw new InternalServerErrorException();
+    }
+  }
+
+  private validateChargeAmount(amount: number): void {
+    if (amount < 1 || amount > PointService.MAX_POINT_LIMIT) {
       throw new BadRequestException();
     }
+  }
 
-    let updatedPoint: UserPoint;
+  private validateChargeLimit(currentPoint: number, amount: number): void {
+    if (currentPoint + amount > PointService.MAX_POINT_LIMIT) {
+      throw new BadRequestException();
+    }
+  }
 
+  private validateUseAmount(amount: number): void {
+    if (
+      amount < PointService.MIN_USE_AMOUNT ||
+      amount > PointService.MAX_POINT_LIMIT ||
+      amount % PointService.USE_AMOUNT_UNIT !== 0
+    ) {
+      throw new BadRequestException();
+    }
+  }
+
+  private async validateDailyUseLimit(id: number, amount: number): Promise<void> {
+    const histories = await this.getHistoriesSafely(id);
+    const pointsUsedToday = this.calculateDailyUsedPoints(histories);
+
+    if (pointsUsedToday + amount > PointService.DAILY_USE_LIMIT) {
+      throw new BadRequestException();
+    }
+  }
+
+  private validateSufficientBalance(currentPoint: number, amount: number): void {
+    if (currentPoint < amount) {
+      throw new BadRequestException();
+    }
+  }
+
+  private async getUserPointSafely(id: number): Promise<UserPoint> {
     try {
-      updatedPoint = await this.userDb.insertOrUpdate(id, newPoint);
-      await this.historyDb.insert(id, amount, TransactionType.USE, Date.now());
+      return await this.userDb.selectById(id);
     } catch (error) {
       throw new InternalServerErrorException();
     }
+  }
 
-    return updatedPoint;
+  private async getHistoriesSafely(id: number): Promise<PointHistory[]> {
+    try {
+      return await this.historyDb.selectAllByUserId(id);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
+  }
+
+  private async updatePointWithHistory(
+    id: number,
+    newPoint: number,
+    amount: number,
+    type: TransactionType,
+  ): Promise<UserPoint> {
+    try {
+      const updatedPoint = await this.userDb.insertOrUpdate(id, newPoint);
+      await this.historyDb.insert(id, amount, type, Date.now());
+      return updatedPoint;
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
+  }
+
+  private sortHistoriesByTimeDesc(histories: PointHistory[]): PointHistory[] {
+    return histories.sort((a, b) => b.timeMillis - a.timeMillis);
+  }
+
+  private calculateDailyUsedPoints(histories: PointHistory[]): number {
+    const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
+
+    return histories
+      .filter(
+        history => history.type === TransactionType.USE && history.timeMillis > oneDayAgo,
+      )
+      .reduce((acc, history) => acc + history.amount, 0);
   }
 }

--- a/src/point/policy/point.policy.spec.ts
+++ b/src/point/policy/point.policy.spec.ts
@@ -1,0 +1,199 @@
+import { BadRequestException, InternalServerErrorException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PointPolicy } from './point.policy';
+
+describe('PointPolicy', () => {
+  let pointPolicy: PointPolicy;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PointPolicy],
+    }).compile();
+
+    pointPolicy = module.get<PointPolicy>(PointPolicy);
+  });
+
+  describe('checkPointRange', () => {
+    it('포인트가 유효한 범위(0 이상)일 때 성공해야 한다', () => {
+      expect(() => pointPolicy.checkPointRange(0)).not.toThrow();
+      expect(() => pointPolicy.checkPointRange(1000)).not.toThrow();
+      expect(() => pointPolicy.checkPointRange(10_000_000)).not.toThrow();
+    });
+
+    it('포인트가 0 미만일 때 예외를 발생시켜야 한다', () => {
+      expect(() => pointPolicy.checkPointRange(-1)).toThrow(InternalServerErrorException);
+      expect(() => pointPolicy.checkPointRange(-100)).toThrow(
+        InternalServerErrorException,
+      );
+    });
+
+    it('포인트가 최대 한도를 초과할 때 예외를 발생시켜야 한다', () => {
+      expect(() => pointPolicy.checkPointRange(10_000_001)).toThrow(
+        InternalServerErrorException,
+      );
+      expect(() => pointPolicy.checkPointRange(20_000_000)).toThrow(
+        InternalServerErrorException,
+      );
+    });
+
+    it('예외 메시지가 올바른지 확인해야 한다', () => {
+      expect(() => pointPolicy.checkPointRange(-1)).toThrow('비정상 포인트 범위');
+      expect(() => pointPolicy.checkPointRange(10_000_001)).toThrow('비정상 포인트 범위');
+    });
+  });
+
+  describe('checkChargeAmount', () => {
+    it('충전 금액이 유효한 범위(1 이상)일 때 성공해야 한다', () => {
+      expect(() => pointPolicy.checkChargeAmount(1)).not.toThrow();
+      expect(() => pointPolicy.checkChargeAmount(1000)).not.toThrow();
+      expect(() => pointPolicy.checkChargeAmount(10_000_000)).not.toThrow();
+    });
+
+    it('충전 금액이 1 미만일 때 예외를 발생시켜야 한다', () => {
+      expect(() => pointPolicy.checkChargeAmount(0)).toThrow(BadRequestException);
+      expect(() => pointPolicy.checkChargeAmount(-1)).toThrow(BadRequestException);
+    });
+
+    it('충전 금액이 최대 한도를 초과할 때 예외를 발생시켜야 한다', () => {
+      expect(() => pointPolicy.checkChargeAmount(10_000_001)).toThrow(
+        BadRequestException,
+      );
+      expect(() => pointPolicy.checkChargeAmount(20_000_000)).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('예외 메시지가 올바른지 확인해야 한다', () => {
+      expect(() => pointPolicy.checkChargeAmount(0)).toThrow(
+        '충전 금액이 유효하지 않습니다.',
+      );
+      expect(() => pointPolicy.checkChargeAmount(10_000_001)).toThrow(
+        '충전 금액이 유효하지 않습니다.',
+      );
+    });
+  });
+
+  describe('checkChargeLimit', () => {
+    it('충전 후 포인트가 한도 내일 때 성공해야 한다', () => {
+      expect(() => pointPolicy.checkChargeLimit(5_000_000, 1_000_000)).not.toThrow();
+      expect(() => pointPolicy.checkChargeLimit(0, 10_000_000)).not.toThrow();
+      expect(() => pointPolicy.checkChargeLimit(9_999_999, 1)).not.toThrow();
+    });
+
+    it('충전 후 포인트가 한도를 초과할 때 예외를 발생시켜야 한다', () => {
+      expect(() => pointPolicy.checkChargeLimit(5_000_000, 5_000_001)).toThrow(
+        BadRequestException,
+      );
+      expect(() => pointPolicy.checkChargeLimit(10_000_000, 1)).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('예외 메시지가 올바른지 확인해야 한다', () => {
+      expect(() => pointPolicy.checkChargeLimit(5_000_000, 5_000_001)).toThrow(
+        '포인트 한도 초과',
+      );
+    });
+  });
+
+  describe('checkUseAmount', () => {
+    it('사용 금액이 유효할 때 성공해야 한다', () => {
+      expect(() => pointPolicy.checkUseAmount(100)).not.toThrow();
+      expect(() => pointPolicy.checkUseAmount(200)).not.toThrow();
+      expect(() => pointPolicy.checkUseAmount(1000)).not.toThrow();
+      expect(() => pointPolicy.checkUseAmount(10_000_000)).not.toThrow();
+    });
+
+    it('사용 금액이 최소 금액 미만일 때 예외를 발생시켜야 한다', () => {
+      expect(() => pointPolicy.checkUseAmount(99)).toThrow(BadRequestException);
+      expect(() => pointPolicy.checkUseAmount(0)).toThrow(BadRequestException);
+      expect(() => pointPolicy.checkUseAmount(-1)).toThrow(BadRequestException);
+    });
+
+    it('사용 금액이 최대 한도를 초과할 때 예외를 발생시켜야 한다', () => {
+      expect(() => pointPolicy.checkUseAmount(10_000_001)).toThrow(BadRequestException);
+      expect(() => pointPolicy.checkUseAmount(20_000_000)).toThrow(BadRequestException);
+    });
+
+    it('사용 금액이 100 단위가 아닐 때 예외를 발생시켜야 한다', () => {
+      expect(() => pointPolicy.checkUseAmount(101)).toThrow(BadRequestException);
+      expect(() => pointPolicy.checkUseAmount(150)).toThrow(BadRequestException);
+      expect(() => pointPolicy.checkUseAmount(999)).toThrow(BadRequestException);
+    });
+
+    it('예외 메시지가 올바른지 확인해야 한다', () => {
+      expect(() => pointPolicy.checkUseAmount(99)).toThrow('포인트 사용 단위 오류');
+      expect(() => pointPolicy.checkUseAmount(101)).toThrow('포인트 사용 단위 오류');
+      expect(() => pointPolicy.checkUseAmount(10_000_001)).toThrow(
+        '포인트 사용 단위 오류',
+      );
+    });
+  });
+
+  describe('checkDailyUseLimit', () => {
+    it('일일 사용 한도 내일 때 성공해야 한다', () => {
+      expect(() => pointPolicy.checkDailyUseLimit(0, 50_000)).not.toThrow();
+      expect(() => pointPolicy.checkDailyUseLimit(30_000, 20_000)).not.toThrow();
+      expect(() => pointPolicy.checkDailyUseLimit(49_999, 1)).not.toThrow();
+    });
+
+    it('일일 사용 한도를 초과할 때 예외를 발생시켜야 한다', () => {
+      expect(() => pointPolicy.checkDailyUseLimit(0, 50_001)).toThrow(
+        BadRequestException,
+      );
+      expect(() => pointPolicy.checkDailyUseLimit(30_000, 20_001)).toThrow(
+        BadRequestException,
+      );
+      expect(() => pointPolicy.checkDailyUseLimit(50_000, 1)).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('예외 메시지가 올바른지 확인해야 한다', () => {
+      expect(() => pointPolicy.checkDailyUseLimit(0, 50_001)).toThrow(
+        '일일 사용 한도 초과',
+      );
+    });
+  });
+
+  describe('checkSufficientBalance', () => {
+    it('잔액이 충분할 때 성공해야 한다', () => {
+      expect(() => pointPolicy.checkSufficientBalance(1000, 1000)).not.toThrow();
+      expect(() => pointPolicy.checkSufficientBalance(2000, 1000)).not.toThrow();
+      expect(() =>
+        pointPolicy.checkSufficientBalance(10_000_000, 5_000_000),
+      ).not.toThrow();
+    });
+
+    it('잔액이 부족할 때 예외를 발생시켜야 한다', () => {
+      expect(() => pointPolicy.checkSufficientBalance(999, 1000)).toThrow(
+        BadRequestException,
+      );
+      expect(() => pointPolicy.checkSufficientBalance(0, 1)).toThrow(BadRequestException);
+      expect(() => pointPolicy.checkSufficientBalance(5_000_000, 10_000_000)).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('예외 메시지가 올바른지 확인해야 한다', () => {
+      expect(() => pointPolicy.checkSufficientBalance(999, 1000)).toThrow('잔액 부족');
+    });
+  });
+
+  describe('상수 값 검증', () => {
+    it('정의된 상수들이 올바른 값을 가져야 한다', () => {
+      // 이 테스트는 상수 값이 변경되었을 때 알 수 있도록 하는 안전장치입니다
+      expect(() => pointPolicy.checkPointRange(10_000_000)).not.toThrow();
+      expect(() => pointPolicy.checkPointRange(10_000_001)).toThrow();
+
+      expect(() => pointPolicy.checkDailyUseLimit(0, 50_000)).not.toThrow();
+      expect(() => pointPolicy.checkDailyUseLimit(0, 50_001)).toThrow();
+
+      expect(() => pointPolicy.checkUseAmount(100)).not.toThrow();
+      expect(() => pointPolicy.checkUseAmount(99)).toThrow();
+
+      expect(() => pointPolicy.checkUseAmount(200)).not.toThrow();
+      expect(() => pointPolicy.checkUseAmount(150)).toThrow();
+    });
+  });
+});

--- a/src/point/policy/point.policy.ts
+++ b/src/point/policy/point.policy.ts
@@ -1,0 +1,53 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+
+@Injectable()
+export class PointPolicy {
+  private static readonly MAX_POINT_LIMIT = 10_000_000;
+  private static readonly DAILY_USE_LIMIT = 50_000;
+  private static readonly MIN_USE_AMOUNT = 100;
+  private static readonly USE_AMOUNT_UNIT = 100;
+
+  checkPointRange(point: number): void {
+    if (point < 0 || point > PointPolicy.MAX_POINT_LIMIT) {
+      throw new InternalServerErrorException('비정상 포인트 범위');
+    }
+  }
+
+  checkChargeAmount(amount: number): void {
+    if (amount < 1 || amount > PointPolicy.MAX_POINT_LIMIT) {
+      throw new BadRequestException('충전 금액이 유효하지 않습니다.');
+    }
+  }
+
+  checkChargeLimit(currentPoint: number, amount: number): void {
+    if (currentPoint + amount > PointPolicy.MAX_POINT_LIMIT) {
+      throw new BadRequestException('포인트 한도 초과');
+    }
+  }
+
+  checkUseAmount(amount: number): void {
+    if (
+      amount < PointPolicy.MIN_USE_AMOUNT ||
+      amount > PointPolicy.MAX_POINT_LIMIT ||
+      amount % PointPolicy.USE_AMOUNT_UNIT !== 0
+    ) {
+      throw new BadRequestException('포인트 사용 단위 오류');
+    }
+  }
+
+  checkDailyUseLimit(pointsUsedToday: number, amount: number): void {
+    if (pointsUsedToday + amount > PointPolicy.DAILY_USE_LIMIT) {
+      throw new BadRequestException('일일 사용 한도 초과');
+    }
+  }
+
+  checkSufficientBalance(currentPoint: number, amount: number): void {
+    if (currentPoint < amount) {
+      throw new BadRequestException('잔액 부족');
+    }
+  }
+}

--- a/src/point/repository/point.repository.spec.ts
+++ b/src/point/repository/point.repository.spec.ts
@@ -1,0 +1,176 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InternalServerErrorException } from '@nestjs/common';
+import { PointRepository } from './point.repository';
+import { UserPointTable } from '../../database/userpoint.table';
+import { PointHistoryTable } from '../../database/pointhistory.table';
+import { TransactionType } from '../point.model';
+
+describe('PointRepository', () => {
+  let repository: PointRepository;
+  let userPointTable: jest.Mocked<UserPointTable>;
+  let pointHistoryTable: jest.Mocked<PointHistoryTable>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PointRepository,
+        {
+          provide: UserPointTable,
+          useValue: {
+            selectById: jest.fn(),
+            insertOrUpdate: jest.fn(),
+          },
+        },
+        {
+          provide: PointHistoryTable,
+          useValue: {
+            selectAllByUserId: jest.fn(),
+            insert: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    repository = module.get<PointRepository>(PointRepository);
+    userPointTable = module.get(UserPointTable);
+    pointHistoryTable = module.get(PointHistoryTable);
+  });
+
+  describe('getUserPoint', () => {
+    it('사용자 포인트를 정상적으로 조회해야 한다', async () => {
+      // Given
+      const userId = 1;
+      const expectedUserPoint = {
+        id: 1,
+        point: 1000,
+        updateMillis: 123456789,
+      };
+      userPointTable.selectById.mockResolvedValue(expectedUserPoint);
+
+      // When
+      const result = await repository.getUserPoint(userId);
+
+      // Then
+      expect(userPointTable.selectById).toHaveBeenCalledWith(userId);
+      expect(result).toEqual(expectedUserPoint);
+    });
+
+    it('데이터베이스 에러 발생시 InternalServerErrorException을 발생시켜야 한다', async () => {
+      // Given
+      const userId = 1;
+      userPointTable.selectById.mockRejectedValue(new Error('Database error'));
+
+      // When & Then
+      await expect(repository.getUserPoint(userId)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe('getHistories', () => {
+    it('포인트 히스토리를 정상적으로 조회해야 한다', async () => {
+      // Given
+      const userId = 1;
+      const expectedHistories = [
+        {
+          id: 1,
+          userId: 1,
+          amount: 1000,
+          type: TransactionType.CHARGE,
+          timeMillis: 123456789,
+        },
+        {
+          id: 2,
+          userId: 1,
+          amount: 500,
+          type: TransactionType.USE,
+          timeMillis: 123456790,
+        },
+      ];
+      pointHistoryTable.selectAllByUserId.mockResolvedValue(expectedHistories);
+
+      // When
+      const result = await repository.getHistories(userId);
+
+      // Then
+      expect(pointHistoryTable.selectAllByUserId).toHaveBeenCalledWith(userId);
+      expect(result).toEqual(expectedHistories);
+    });
+
+    it('데이터베이스 에러 발생시 InternalServerErrorException을 발생시켜야 한다', async () => {
+      // Given
+      const userId = 1;
+      pointHistoryTable.selectAllByUserId.mockRejectedValue(new Error('Database error'));
+
+      // When & Then
+      await expect(repository.getHistories(userId)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe('updatePointWithHistory', () => {
+    beforeEach(() => {
+      jest.spyOn(Date, 'now').mockReturnValue(123456789);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('포인트 업데이트와 히스토리 기록을 정상적으로 수행해야 한다', async () => {
+      // Given
+      const userId = 1;
+      const newPoint = 1500;
+      const amount = 500;
+      const type = TransactionType.CHARGE;
+      const expectedUserPoint = {
+        id: 1,
+        point: 1500,
+        updateMillis: 123456789,
+      };
+
+      userPointTable.insertOrUpdate.mockResolvedValue(expectedUserPoint);
+      pointHistoryTable.insert.mockResolvedValue({
+        id: 1,
+        userId: 1,
+        amount: 500,
+        type: TransactionType.CHARGE,
+        timeMillis: 123456789,
+      });
+
+      // When
+      const result = await repository.updatePointWithHistory(
+        userId,
+        newPoint,
+        amount,
+        type,
+      );
+
+      // Then
+      expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(userId, newPoint);
+      expect(pointHistoryTable.insert).toHaveBeenCalledWith(
+        userId,
+        amount,
+        type,
+        123456789,
+      );
+      expect(result).toEqual(expectedUserPoint);
+    });
+
+    it('데이터베이스 에러 발생시 InternalServerErrorException을 발생시켜야 한다', async () => {
+      // Given
+      const userId = 1;
+      const newPoint = 1500;
+      const amount = 500;
+      const type = TransactionType.CHARGE;
+
+      userPointTable.insertOrUpdate.mockRejectedValue(new Error('Database error'));
+
+      // When & Then
+      await expect(
+        repository.updatePointWithHistory(userId, newPoint, amount, type),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+});

--- a/src/point/repository/point.repository.ts
+++ b/src/point/repository/point.repository.ts
@@ -1,0 +1,43 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { PointHistory, TransactionType, UserPoint } from '../point.model';
+import { UserPointTable } from 'src/database/userpoint.table';
+import { PointHistoryTable } from 'src/database/pointhistory.table';
+
+@Injectable()
+export class PointRepository {
+  constructor(
+    private readonly userDb: UserPointTable,
+    private readonly historyDb: PointHistoryTable,
+  ) {}
+
+  async getUserPoint(id: number): Promise<UserPoint> {
+    try {
+      return await this.userDb.selectById(id);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
+  }
+
+  async getHistories(id: number): Promise<PointHistory[]> {
+    try {
+      return await this.historyDb.selectAllByUserId(id);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
+  }
+
+  async updatePointWithHistory(
+    id: number,
+    newPoint: number,
+    amount: number,
+    type: TransactionType,
+  ): Promise<UserPoint> {
+    try {
+      const updatedPoint = await this.userDb.insertOrUpdate(id, newPoint);
+      await this.historyDb.insert(id, amount, type, Date.now());
+      return updatedPoint;
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
+  }
+}


### PR DESCRIPTION
### 💬 배경
-  솔직히 프로젝트가 작아서 controller에서 부터 전체 통합 테스트 돌려도 무방하다고 느껴졌습니다. 코드량이 많아져야 코드 리팩토링이 더 설득력이 생길 것 같습니다.
- 다만, 비즈니스 로직을 추출하는 것에 의미가 있다고 느꼈습니다.
  - controller(pipe포함한) 계층에서는 데이터 검증을 담당
  - policy, service에서 핵심 비즈니스 로직 담당
  - repository에서 외부 데이터 의존성 담당
  - 비즈니스 로직을 최대한 추출한 코드는 테스트 하기도 좋아보였습니다.
- 테스팅 관련
  - Pure TDD를 앞선 PR들에서 충분히 경험했다고 판단하여 이제 원래 실무에서 하던대로 Blackbox에 가까운 TDD와 Whitebox에 가까운 Structural Testing을 섞어서 사용
  - Stub을 적는 시간 줄어듦. 다만 엣지 케이스에 대한 꼼꼼함과 감수성은 떨어질수도.

### 📚 커밋 로그

- 컨트롤러, 서비스 분리 리팩토링
  - controller <=> service 테스트 분리: [0afa951](https://github.com/seho0808/hh-9-be/pull/9/commits/0afa951d2defe8b039a686b5b34b4f9636ac3ab4)
  - controller <=> service 구현 분리: [64f05a4](https://github.com/seho0808/hh-9-be/pull/9/commits/64f05a468e49681f4ebdaac6df4f4c41d72b16ff)

- 서비스 가독성 리팩토링
  - service 함수 분리 리팩토링: [b4fd0ff](https://github.com/seho0808/hh-9-be/pull/9/commits/b4fd0fff4698b3f6b64cee9557799dc07c0d0e73)

- 서비스에서 policy, repository 분리
  - service 레이어 policy, repository 분리: [0a74348](https://github.com/seho0808/hh-9-be/pull/9/commits/0a743488ec05a0b8b3b6b08e7be3575b0dcadbad)
  - policy 유닛 테스팅: [bf9ce10](https://github.com/seho0808/hh-9-be/pull/9/commits/bf9ce104c42b715c08dfa9b0d4acc0e5b225e1da)
  - repository 레이어 유닛 테스팅: [7a99552](https://github.com/seho0808/hh-9-be/pull/9/commits/7a995527115a3b379cdc854025f0b57209ace7cb)
  - service 레이어 policy는 실제 객체로, repository는 목으로: [1f85183](https://github.com/seho0808/hh-9-be/pull/9/commits/1f85183a9a8718922a389cd98ecef208e2ad801c)

### 🤔 고민 포인트

Q: 레이어드 아키텍처는 테스터블한가?
A: 클린 아키텍처가 훨씬 테스터블하다고 생각함. 다만 이번 과제 스코프에서는 레이어드로 할 수 있는 만큼 하는 것을 목표로 하고 있음. 애초에 레이어드 아키텍처는 엔티티가 메모리에 있지 않고 db에 있기 때문에 통합 테스트가 느리고 비즈니스 로직이 읽기 쉽도록 신경도 많이 써주어야함. - 이미 실무를 하면서 클린 아키텍처로 너무 가고 싶었었다. - https://seholee.com/blog/testable-code-1/

Q: 과연 controller, repository 레이어를 유닛 테스팅하는 것이 의미가 있을까?
A: 현재 나의 소스 코드에서는 제거해도 그만인 수준의 mock 구현체들 뿐이다. 실제 구현은 거의 없다. repository의 경우 던지는 오류는 확인하는 것이 나쁘지 않은 정도? 이럴 경우 통합이나 e2e에서 대부분 커버되기 때문에 관리 포인트를 줄이는 측면에서 unit test모두 제거해도 된다고 생각한다. 다만 이미 작성했기도하고 프로젝트 크기가 크지 않으니 지금은 유지중이다. 만약 도메인이 여러개로 늘어나고 유지보수에 이슈가 생긴다면 e2e랑 통합에서 최대한 관장하고 단순 컨트롤러와 단순 레포지토리 조회 등은 제거해도 무방하다고 생각한다. 물론 복잡한 컨트롤러나 레포지토리 로직이 있다면 유닛 테스트 적극 활용 필요함.

Q: service 레이어에서 policy, repository 두 개의 객체 DI를 받는데 왜 policy만 리얼로 쓰고 repository는 모킹하는가?
A: Policy는 매우 중요한 비즈니스 로직이다. 서비스에서 통합으로 한 번 더해도 아쉽지 않은 면이 있다. 인간, ai 모두 완벽하지 않기 때문에 중요한 로직은 중복된 테스트가 꽤 있어도 유닛에서 한 번, 통합에서 한 번더 하는 것이 슬기롭다고 생각했다. Policy는 비록 DI 되는 객체이지만 서비스 레이어의 일부로 취급하는 것이 맞다고 생각한다. 반대로 Repository는 db에 더 가까운 db를 위한 오류 처리들을 담당하는 것이 맞아서 격리하는 것이 더 깔끔해보였다.

Q: 애초에 policy라는 건 어디서 나온것인가? 그냥 서비스 레이어에 합쳐놓지 왜 분리했는가?
A: 클린 아키텍처 기준으로는 엔티티 내에 들어갈 수 있는 로직임. 클린 아키텍처와 비교하자면 내 코드에서 usecase는 서비스 레이어이고, entity는 유스케이스 레이어임. 이렇게 비즈니스 로직 핵심 정책만 분리해놓으니 서비스 레이어에서는 가독성이 극단적으로 높아지게됨.
 