### PR TITLE
test: toHaveBeenCalled 적소에만 사용하여 리팩토링 저항성 강화

### DIFF
--- a/src/point/controller/point.controller.spec.ts
+++ b/src/point/controller/point.controller.spec.ts
@@ -40,7 +40,6 @@ describe('PointController', () => {
 
       const result = await controller.point(1);
 
-      expect(pointService.getPoint).toHaveBeenCalledWith(1);
       expect(result).toEqual(mockResult);
     });
 
@@ -68,7 +67,6 @@ describe('PointController', () => {
 
       const result = await controller.history(1);
 
-      expect(pointService.getHistory).toHaveBeenCalledWith(1);
       expect(result).toEqual(mockResult);
     });
 
@@ -92,7 +90,6 @@ describe('PointController', () => {
 
       const result = await controller.charge(1, { amount: 100 });
 
-      expect(pointService.chargePoint).toHaveBeenCalledWith(1, 100);
       expect(result).toEqual(mockResult);
     });
 
@@ -118,7 +115,6 @@ describe('PointController', () => {
 
       const result = await controller.use(1, { amount: 100 });
 
-      expect(pointService.usePoint).toHaveBeenCalledWith(1, 100);
       expect(result).toEqual(mockResult);
     });
 

--- a/src/point/repository/point.repository.spec.ts
+++ b/src/point/repository/point.repository.spec.ts
@@ -38,7 +38,6 @@ describe('PointRepository', () => {
 
   describe('getUserPoint', () => {
     it('사용자 포인트를 정상적으로 조회해야 한다', async () => {
-      // Given
       const userId = 1;
       const expectedUserPoint = {
         id: 1,
@@ -47,20 +46,15 @@ describe('PointRepository', () => {
       };
       userPointTable.selectById.mockResolvedValue(expectedUserPoint);
 
-      // When
       const result = await repository.getUserPoint(userId);
 
-      // Then
-      expect(userPointTable.selectById).toHaveBeenCalledWith(userId);
       expect(result).toEqual(expectedUserPoint);
     });
 
     it('데이터베이스 에러 발생시 InternalServerErrorException을 발생시켜야 한다', async () => {
-      // Given
       const userId = 1;
       userPointTable.selectById.mockRejectedValue(new Error('Database error'));
 
-      // When & Then
       await expect(repository.getUserPoint(userId)).rejects.toThrow(
         InternalServerErrorException,
       );
@@ -69,7 +63,6 @@ describe('PointRepository', () => {
 
   describe('getHistories', () => {
     it('포인트 히스토리를 정상적으로 조회해야 한다', async () => {
-      // Given
       const userId = 1;
       const expectedHistories = [
         {
@@ -89,20 +82,15 @@ describe('PointRepository', () => {
       ];
       pointHistoryTable.selectAllByUserId.mockResolvedValue(expectedHistories);
 
-      // When
       const result = await repository.getHistories(userId);
 
-      // Then
-      expect(pointHistoryTable.selectAllByUserId).toHaveBeenCalledWith(userId);
       expect(result).toEqual(expectedHistories);
     });
 
     it('데이터베이스 에러 발생시 InternalServerErrorException을 발생시켜야 한다', async () => {
-      // Given
       const userId = 1;
       pointHistoryTable.selectAllByUserId.mockRejectedValue(new Error('Database error'));
 
-      // When & Then
       await expect(repository.getHistories(userId)).rejects.toThrow(
         InternalServerErrorException,
       );
@@ -139,7 +127,13 @@ describe('PointRepository', () => {
         timeMillis: 123456789,
       });
 
-      // When
+      expect(pointHistoryTable.insert).toHaveBeenCalledWith(
+        userId,
+        amount,
+        type,
+        123456789,
+      );
+
       const result = await repository.updatePointWithHistory(
         userId,
         newPoint,
@@ -147,14 +141,6 @@ describe('PointRepository', () => {
         type,
       );
 
-      // Then
-      expect(userPointTable.insertOrUpdate).toHaveBeenCalledWith(userId, newPoint);
-      expect(pointHistoryTable.insert).toHaveBeenCalledWith(
-        userId,
-        amount,
-        type,
-        123456789,
-      );
       expect(result).toEqual(expectedUserPoint);
     });
 
@@ -167,7 +153,6 @@ describe('PointRepository', () => {
 
       userPointTable.insertOrUpdate.mockRejectedValue(new Error('Database error'));
 
-      // When & Then
       await expect(
         repository.updatePointWithHistory(userId, newPoint, amount, type),
       ).rejects.toThrow(InternalServerErrorException);


### PR DESCRIPTION
### 💬 배경

<!-- 첫 번째 이미지 -->
<img src="https://github.com/user-attachments/assets/ae864ae5-ecc6-4e1e-aba8-ec4d2de80b5e" width="300" />

<!-- 두 번째 이미지 -->
<img src="https://github.com/user-attachments/assets/51fa7fa4-1ff6-4702-afcb-4a6be9861ac6" width="300" />


https://livebook.manning.com/book/unit-testing/chapter-4/v-3/158



Vladimir Khorikov의 4장 6장을 대충 훑어보고 새로 든 생각: "과연 나의 유닛 테스트들은 리팩토링 저항성과 회귀에 강한가?"

Khorikov는 위 세 가지 기둥 중에 하나가 0이면 그냥 무쓸모 테스트라고한다. 나도 동의한다.

- 현재의 repository, controller은 거의 아무 로직이 없고 다른 계층이 모든 걸 위임하고 있다.
- 그래서 unit test도 목 의존도가 높다.
- 그렇다보니 "회귀 방지" 관점에서 점수가 0에 가깝다.
- 사실 실무에서는 삭제하여 관리포인트를 줄이는 것이 타당하다.
- 지운다면 내가 해볼 수 있는 최대한으로 고도화해보고 지우고 싶었다.

그러면 매우 thin한 repository, controller의 test를 어떻게하면 그나마 쓸모있게 바꿀까 고민했다. 그러려면 적어도 리팩토링 저항성이라도 매우 높아야한다고 생각했다.

그러고나서 다시 코드를 보니 toHaveBennCalled가 매우 거슬렸다. 이는 테케가 내부 구조를 알고 있는 상태여서 리팩토링할 때 걸림돌이 된다. 

####  필요한 toHaveBeenCalled vs 필요없는 toHaveBeenCalled

6/8 새벽
- 고민 후 결론: 필요한 경우는 리턴값으로 검증이 불가한 경우 뿐. 그럴 때에는 toHaveBeenCalled 쓸 수 밖에 없다.
  - 이유는 리팩토링 저항성을 최대화하려면 내부 구현을 모를 수록 좋기 때문임.

6/8 아침
- 더 많은 고민 후 추가된 로직: 중요한 호출 로직은 toHaveBeenCalled 쓰는게 유리할 수도 있어보인다.
  - 이유는 toHaveBeenCalled를 쓰면 회귀 저항성은 오히려 올려줄 수 있기 때문이다!
  - 다만 모든 함수에 쓰면 리팩토링이 너무 힘들어지지만 중요한 함수나 인자에 toHaveBeenCalledWith/Times 등의 함수를 쓰면 리팩토링 저항성을 10 정도 희생해서 회귀 저항성을 30-40 가져가는 상황이 나올 수도 있다.

### 📚 커밋 로그

- controller test toHaveBeenCalled 호출 제거: [f483323](https://github.com/seho0808/hh-9-be/pull/11/commits/f48332320f25df037342c9932def25010aae06e9)
- repository test toHaveBeenCalled 호출 대부분 제거: [358cdaa](https://github.com/seho0808/hh-9-be/pull/11/commits/358cdaa579a073acfefd2b5e3fb09058a4390702)
