### PR TITLE
refactor: 서비스 레이어 가독성, 테스트 개선

### DIFF
--- a/src/point/repository/point.repository.spec.ts
+++ b/src/point/repository/point.repository.spec.ts
@@ -127,18 +127,18 @@ describe('PointRepository', () => {
         timeMillis: 123456789,
       });
 
-      expect(pointHistoryTable.insert).toHaveBeenCalledWith(
-        userId,
-        amount,
-        type,
-        123456789,
-      );
-
       const result = await repository.updatePointWithHistory(
         userId,
         newPoint,
         amount,
         type,
+      );
+
+      expect(pointHistoryTable.insert).toHaveBeenCalledWith(
+        userId,
+        amount,
+        type,
+        123456789,
       );
 
       expect(result).toEqual(expectedUserPoint);

--- a/src/point/service/point.service.ts
+++ b/src/point/service/point.service.ts
@@ -40,11 +40,11 @@ export class PointService {
     this.policy.checkUseAmount(amount);
 
     const userPoint = await this.repository.getUserPoint(id);
-    const histories = await this.repository.getHistories(id);
+    this.policy.checkSufficientBalance(userPoint.point, amount);
 
+    const histories = await this.repository.getHistories(id);
     const pointsUsedToday = this.calculateDailyUsedPoints(histories);
     this.policy.checkDailyUseLimit(pointsUsedToday, amount);
-    this.policy.checkSufficientBalance(userPoint.point, amount);
 
     const newPoint = userPoint.point - amount;
     return await this.repository.updatePointWithHistory(

--- a/src/point/service/point.service.ts
+++ b/src/point/service/point.service.ts
@@ -24,10 +24,10 @@ export class PointService {
   async chargePoint(id: number, amount: number): Promise<UserPoint> {
     this.policy.checkChargeAmount(amount);
 
-    const currentPoint = await this.repository.getUserPoint(id);
-    this.policy.checkChargeLimit(currentPoint.point, amount);
+    const userPoint = await this.repository.getUserPoint(id);
+    this.policy.checkChargeLimit(userPoint.point, amount);
 
-    const newPoint = currentPoint.point + amount;
+    const newPoint = userPoint.point + amount;
     return await this.repository.updatePointWithHistory(
       id,
       newPoint,
@@ -39,14 +39,14 @@ export class PointService {
   async usePoint(id: number, amount: number): Promise<UserPoint> {
     this.policy.checkUseAmount(amount);
 
-    const currentPoint = await this.repository.getUserPoint(id);
+    const userPoint = await this.repository.getUserPoint(id);
     const histories = await this.repository.getHistories(id);
 
     const pointsUsedToday = this.calculateDailyUsedPoints(histories);
     this.policy.checkDailyUseLimit(pointsUsedToday, amount);
-    this.policy.checkSufficientBalance(currentPoint.point, amount);
+    this.policy.checkSufficientBalance(userPoint.point, amount);
 
-    const newPoint = currentPoint.point - amount;
+    const newPoint = userPoint.point - amount;
     return await this.repository.updatePointWithHistory(
       id,
       newPoint,

--- a/src/point/service/policy/point.policy.spec.ts
+++ b/src/point/service/policy/point.policy.spec.ts
@@ -17,7 +17,9 @@ describe('PointPolicy', () => {
     it('포인트가 유효한 범위(0 이상)일 때 성공해야 한다', () => {
       expect(() => pointPolicy.checkPointRange(0)).not.toThrow();
       expect(() => pointPolicy.checkPointRange(1000)).not.toThrow();
-      expect(() => pointPolicy.checkPointRange(10_000_000)).not.toThrow();
+      expect(() =>
+        pointPolicy.checkPointRange(PointPolicy.MAX_POINT_LIMIT),
+      ).not.toThrow();
     });
 
     it('포인트가 0 미만일 때 예외를 발생시켜야 한다', () => {
@@ -28,17 +30,19 @@ describe('PointPolicy', () => {
     });
 
     it('포인트가 최대 한도를 초과할 때 예외를 발생시켜야 한다', () => {
-      expect(() => pointPolicy.checkPointRange(10_000_001)).toThrow(
+      expect(() => pointPolicy.checkPointRange(PointPolicy.MAX_POINT_LIMIT + 1)).toThrow(
         InternalServerErrorException,
       );
-      expect(() => pointPolicy.checkPointRange(20_000_000)).toThrow(
+      expect(() => pointPolicy.checkPointRange(PointPolicy.MAX_POINT_LIMIT * 2)).toThrow(
         InternalServerErrorException,
       );
     });
 
     it('예외 메시지가 올바른지 확인해야 한다', () => {
       expect(() => pointPolicy.checkPointRange(-1)).toThrow('비정상 포인트 범위');
-      expect(() => pointPolicy.checkPointRange(10_000_001)).toThrow('비정상 포인트 범위');
+      expect(() => pointPolicy.checkPointRange(PointPolicy.MAX_POINT_LIMIT + 1)).toThrow(
+        '비정상 포인트 범위',
+      );
     });
   });
 
@@ -46,7 +50,9 @@ describe('PointPolicy', () => {
     it('충전 금액이 유효한 범위(1 이상)일 때 성공해야 한다', () => {
       expect(() => pointPolicy.checkChargeAmount(1)).not.toThrow();
       expect(() => pointPolicy.checkChargeAmount(1000)).not.toThrow();
-      expect(() => pointPolicy.checkChargeAmount(10_000_000)).not.toThrow();
+      expect(() =>
+        pointPolicy.checkChargeAmount(PointPolicy.MAX_POINT_LIMIT),
+      ).not.toThrow();
     });
 
     it('충전 금액이 1 미만일 때 예외를 발생시켜야 한다', () => {
@@ -55,76 +61,106 @@ describe('PointPolicy', () => {
     });
 
     it('충전 금액이 최대 한도를 초과할 때 예외를 발생시켜야 한다', () => {
-      expect(() => pointPolicy.checkChargeAmount(10_000_001)).toThrow(
-        BadRequestException,
-      );
-      expect(() => pointPolicy.checkChargeAmount(20_000_000)).toThrow(
-        BadRequestException,
-      );
+      expect(() =>
+        pointPolicy.checkChargeAmount(PointPolicy.MAX_POINT_LIMIT + 1),
+      ).toThrow(BadRequestException);
+      expect(() =>
+        pointPolicy.checkChargeAmount(PointPolicy.MAX_POINT_LIMIT * 2),
+      ).toThrow(BadRequestException);
     });
 
     it('예외 메시지가 올바른지 확인해야 한다', () => {
       expect(() => pointPolicy.checkChargeAmount(0)).toThrow(
         '충전 금액이 유효하지 않습니다.',
       );
-      expect(() => pointPolicy.checkChargeAmount(10_000_001)).toThrow(
-        '충전 금액이 유효하지 않습니다.',
-      );
+      expect(() =>
+        pointPolicy.checkChargeAmount(PointPolicy.MAX_POINT_LIMIT + 1),
+      ).toThrow('충전 금액이 유효하지 않습니다.');
     });
   });
 
   describe('checkChargeLimit', () => {
     it('충전 후 포인트가 한도 내일 때 성공해야 한다', () => {
       expect(() => pointPolicy.checkChargeLimit(5_000_000, 1_000_000)).not.toThrow();
-      expect(() => pointPolicy.checkChargeLimit(0, 10_000_000)).not.toThrow();
-      expect(() => pointPolicy.checkChargeLimit(9_999_999, 1)).not.toThrow();
+      expect(() =>
+        pointPolicy.checkChargeLimit(0, PointPolicy.MAX_POINT_LIMIT),
+      ).not.toThrow();
+      expect(() =>
+        pointPolicy.checkChargeLimit(PointPolicy.MAX_POINT_LIMIT - 1, 1),
+      ).not.toThrow();
     });
 
     it('충전 후 포인트가 한도를 초과할 때 예외를 발생시켜야 한다', () => {
-      expect(() => pointPolicy.checkChargeLimit(5_000_000, 5_000_001)).toThrow(
-        BadRequestException,
-      );
-      expect(() => pointPolicy.checkChargeLimit(10_000_000, 1)).toThrow(
+      expect(() =>
+        pointPolicy.checkChargeLimit(
+          5_000_000,
+          PointPolicy.MAX_POINT_LIMIT - 5_000_000 + 1,
+        ),
+      ).toThrow(BadRequestException);
+      expect(() => pointPolicy.checkChargeLimit(PointPolicy.MAX_POINT_LIMIT, 1)).toThrow(
         BadRequestException,
       );
     });
 
     it('예외 메시지가 올바른지 확인해야 한다', () => {
-      expect(() => pointPolicy.checkChargeLimit(5_000_000, 5_000_001)).toThrow(
-        '포인트 한도 초과',
-      );
+      expect(() =>
+        pointPolicy.checkChargeLimit(
+          5_000_000,
+          PointPolicy.MAX_POINT_LIMIT - 5_000_000 + 1,
+        ),
+      ).toThrow('포인트 한도 초과');
     });
   });
 
   describe('checkUseAmount', () => {
     it('사용 금액이 유효할 때 성공해야 한다', () => {
-      expect(() => pointPolicy.checkUseAmount(100)).not.toThrow();
-      expect(() => pointPolicy.checkUseAmount(200)).not.toThrow();
-      expect(() => pointPolicy.checkUseAmount(1000)).not.toThrow();
-      expect(() => pointPolicy.checkUseAmount(10_000_000)).not.toThrow();
+      expect(() => pointPolicy.checkUseAmount(PointPolicy.MIN_USE_AMOUNT)).not.toThrow();
+      expect(() =>
+        pointPolicy.checkUseAmount(PointPolicy.USE_AMOUNT_UNIT * 2),
+      ).not.toThrow();
+      expect(() =>
+        pointPolicy.checkUseAmount(PointPolicy.USE_AMOUNT_UNIT * 10),
+      ).not.toThrow();
+      expect(() => pointPolicy.checkUseAmount(PointPolicy.MAX_POINT_LIMIT)).not.toThrow();
     });
 
     it('사용 금액이 최소 금액 미만일 때 예외를 발생시켜야 한다', () => {
-      expect(() => pointPolicy.checkUseAmount(99)).toThrow(BadRequestException);
+      expect(() => pointPolicy.checkUseAmount(PointPolicy.MIN_USE_AMOUNT - 1)).toThrow(
+        BadRequestException,
+      );
       expect(() => pointPolicy.checkUseAmount(0)).toThrow(BadRequestException);
       expect(() => pointPolicy.checkUseAmount(-1)).toThrow(BadRequestException);
     });
 
     it('사용 금액이 최대 한도를 초과할 때 예외를 발생시켜야 한다', () => {
-      expect(() => pointPolicy.checkUseAmount(10_000_001)).toThrow(BadRequestException);
-      expect(() => pointPolicy.checkUseAmount(20_000_000)).toThrow(BadRequestException);
+      expect(() => pointPolicy.checkUseAmount(PointPolicy.MAX_POINT_LIMIT + 1)).toThrow(
+        BadRequestException,
+      );
+      expect(() => pointPolicy.checkUseAmount(PointPolicy.MAX_POINT_LIMIT * 2)).toThrow(
+        BadRequestException,
+      );
     });
 
     it('사용 금액이 100 단위가 아닐 때 예외를 발생시켜야 한다', () => {
-      expect(() => pointPolicy.checkUseAmount(101)).toThrow(BadRequestException);
-      expect(() => pointPolicy.checkUseAmount(150)).toThrow(BadRequestException);
-      expect(() => pointPolicy.checkUseAmount(999)).toThrow(BadRequestException);
+      expect(() => pointPolicy.checkUseAmount(PointPolicy.MIN_USE_AMOUNT + 1)).toThrow(
+        BadRequestException,
+      );
+      expect(() => pointPolicy.checkUseAmount(PointPolicy.USE_AMOUNT_UNIT + 50)).toThrow(
+        BadRequestException,
+      );
+      expect(() =>
+        pointPolicy.checkUseAmount(PointPolicy.USE_AMOUNT_UNIT * 10 - 1),
+      ).toThrow(BadRequestException);
     });
 
     it('예외 메시지가 올바른지 확인해야 한다', () => {
-      expect(() => pointPolicy.checkUseAmount(99)).toThrow('포인트 사용 단위 오류');
-      expect(() => pointPolicy.checkUseAmount(101)).toThrow('포인트 사용 단위 오류');
-      expect(() => pointPolicy.checkUseAmount(10_000_001)).toThrow(
+      expect(() => pointPolicy.checkUseAmount(PointPolicy.MIN_USE_AMOUNT - 1)).toThrow(
+        '포인트 사용 단위 오류',
+      );
+      expect(() => pointPolicy.checkUseAmount(PointPolicy.MIN_USE_AMOUNT + 1)).toThrow(
+        '포인트 사용 단위 오류',
+      );
+      expect(() => pointPolicy.checkUseAmount(PointPolicy.MAX_POINT_LIMIT + 1)).toThrow(
         '포인트 사용 단위 오류',
       );
     });
@@ -132,27 +168,33 @@ describe('PointPolicy', () => {
 
   describe('checkDailyUseLimit', () => {
     it('일일 사용 한도 내일 때 성공해야 한다', () => {
-      expect(() => pointPolicy.checkDailyUseLimit(0, 50_000)).not.toThrow();
-      expect(() => pointPolicy.checkDailyUseLimit(30_000, 20_000)).not.toThrow();
-      expect(() => pointPolicy.checkDailyUseLimit(49_999, 1)).not.toThrow();
+      expect(() =>
+        pointPolicy.checkDailyUseLimit(0, PointPolicy.DAILY_USE_LIMIT),
+      ).not.toThrow();
+      expect(() =>
+        pointPolicy.checkDailyUseLimit(30_000, PointPolicy.DAILY_USE_LIMIT - 30_000),
+      ).not.toThrow();
+      expect(() =>
+        pointPolicy.checkDailyUseLimit(PointPolicy.DAILY_USE_LIMIT - 1, 1),
+      ).not.toThrow();
     });
 
     it('일일 사용 한도를 초과할 때 예외를 발생시켜야 한다', () => {
-      expect(() => pointPolicy.checkDailyUseLimit(0, 50_001)).toThrow(
-        BadRequestException,
-      );
-      expect(() => pointPolicy.checkDailyUseLimit(30_000, 20_001)).toThrow(
-        BadRequestException,
-      );
-      expect(() => pointPolicy.checkDailyUseLimit(50_000, 1)).toThrow(
-        BadRequestException,
-      );
+      expect(() =>
+        pointPolicy.checkDailyUseLimit(0, PointPolicy.DAILY_USE_LIMIT + 1),
+      ).toThrow(BadRequestException);
+      expect(() =>
+        pointPolicy.checkDailyUseLimit(30_000, PointPolicy.DAILY_USE_LIMIT - 30_000 + 1),
+      ).toThrow(BadRequestException);
+      expect(() =>
+        pointPolicy.checkDailyUseLimit(PointPolicy.DAILY_USE_LIMIT, 1),
+      ).toThrow(BadRequestException);
     });
 
     it('예외 메시지가 올바른지 확인해야 한다', () => {
-      expect(() => pointPolicy.checkDailyUseLimit(0, 50_001)).toThrow(
-        '일일 사용 한도 초과',
-      );
+      expect(() =>
+        pointPolicy.checkDailyUseLimit(0, PointPolicy.DAILY_USE_LIMIT + 1),
+      ).toThrow('일일 사용 한도 초과');
     });
   });
 
@@ -161,7 +203,10 @@ describe('PointPolicy', () => {
       expect(() => pointPolicy.checkSufficientBalance(1000, 1000)).not.toThrow();
       expect(() => pointPolicy.checkSufficientBalance(2000, 1000)).not.toThrow();
       expect(() =>
-        pointPolicy.checkSufficientBalance(10_000_000, 5_000_000),
+        pointPolicy.checkSufficientBalance(
+          PointPolicy.MAX_POINT_LIMIT,
+          PointPolicy.MAX_POINT_LIMIT / 2,
+        ),
       ).not.toThrow();
     });
 
@@ -170,9 +215,12 @@ describe('PointPolicy', () => {
         BadRequestException,
       );
       expect(() => pointPolicy.checkSufficientBalance(0, 1)).toThrow(BadRequestException);
-      expect(() => pointPolicy.checkSufficientBalance(5_000_000, 10_000_000)).toThrow(
-        BadRequestException,
-      );
+      expect(() =>
+        pointPolicy.checkSufficientBalance(
+          PointPolicy.MAX_POINT_LIMIT / 2,
+          PointPolicy.MAX_POINT_LIMIT,
+        ),
+      ).toThrow(BadRequestException);
     });
 
     it('예외 메시지가 올바른지 확인해야 한다', () => {
@@ -184,16 +232,16 @@ describe('PointPolicy', () => {
     it('정의된 상수들이 올바른 값을 가져야 한다', () => {
       // 이 테스트는 상수 값이 변경되었을 때 알 수 있도록 하는 안전장치입니다
       expect(() => pointPolicy.checkPointRange(10_000_000)).not.toThrow();
-      expect(() => pointPolicy.checkPointRange(10_000_001)).toThrow();
+      expect(() => pointPolicy.checkPointRange(10_000_000 + 1)).toThrow();
 
       expect(() => pointPolicy.checkDailyUseLimit(0, 50_000)).not.toThrow();
-      expect(() => pointPolicy.checkDailyUseLimit(0, 50_001)).toThrow();
+      expect(() => pointPolicy.checkDailyUseLimit(0, 50_000 + 1)).toThrow();
 
       expect(() => pointPolicy.checkUseAmount(100)).not.toThrow();
-      expect(() => pointPolicy.checkUseAmount(99)).toThrow();
+      expect(() => pointPolicy.checkUseAmount(100 - 1)).toThrow();
 
       expect(() => pointPolicy.checkUseAmount(200)).not.toThrow();
-      expect(() => pointPolicy.checkUseAmount(150)).toThrow();
+      expect(() => pointPolicy.checkUseAmount(200 + 50)).toThrow();
     });
   });
 });

--- a/src/point/service/policy/point.policy.ts
+++ b/src/point/service/policy/point.policy.ts
@@ -6,10 +6,10 @@ import {
 
 @Injectable()
 export class PointPolicy {
-  private static readonly MAX_POINT_LIMIT = 10_000_000;
-  private static readonly DAILY_USE_LIMIT = 50_000;
-  private static readonly MIN_USE_AMOUNT = 100;
-  private static readonly USE_AMOUNT_UNIT = 100;
+  public static readonly MAX_POINT_LIMIT = 10_000_000;
+  public static readonly DAILY_USE_LIMIT = 50_000;
+  public static readonly MIN_USE_AMOUNT = 100;
+  public static readonly USE_AMOUNT_UNIT = 100;
 
   checkPointRange(point: number): void {
     if (point < 0 || point > PointPolicy.MAX_POINT_LIMIT) {


### PR DESCRIPTION
### 💬 배경

- 서비스 레이어 가독성 개선 리팩토링 진행함.

### 📚 커밋 로그

- policy에 있는 숫자들이 test에서는 공유되고 있지 않던 문제 해결: [3699bfe](https://github.com/seho0808/hh-9-be/pull/12/commits/3699bfe5eb0da850f69027529540c3ad8d35e187)
- point.service 내부 변수 네이밍 변경: [0259812](https://github.com/seho0808/hh-9-be/pull/12/commits/02598126401c8770e3f12a419e51094b2b59968b)
- point.service usePoint 함수 가독성 개선: [799014d](https://github.com/seho0808/hh-9-be/pull/12/commits/799014d2bb7f4b5a35c7614bcce6554e3a9dcc40)
- https://github.com/seho0808/hh-9-be/pull/11 에서 실수로 깨뜨린 테스트 수정: [32bd9d4](https://github.com/seho0808/hh-9-be/pull/12/commits/32bd9d4d9883a596cb3e8fd58365506fddb8b35c)

### 🤔 고민 포인트

#### service - policy 중복 테스트 괜찮은가?

- 현재 service.spec.ts는 sociable unit test, policy.spec.ts는 solitary unit test.
- 내가 느끼기에 어색했던 부분은, 단일 서비스 파일이었던 것을 policy로 나누면서 service.spec.ts가 policy.spec.ts와 유사한 테스트가 몇 개 생겼다는 것임. 이는 비즈니스 로직에 해당함.
- 우리의 궁극적인 목표는 비즈니스 목표 달성하기 => 이것을 위한 서브 KR이 테스트 고도화임. => 그렇다면 우리가 생각해야할 것은 단 한가지임. 비즈니스 목표를 이루는데에 중복 테스트 괜찮은가?
- 중복 테스트의 장단점은 명확함: 안정성 up, 유지보수성 down
- 서비스 레이어는 비즈니스 핵심 계층이기 때문에 오류가 제일 발생하면 안되는 지점임. 그렇기 때문에 중복으로 검증하는 것이 전체 비용을 오히려 절감하는 효과를 낼 수 있음.

#### sociable unit test와 integration test의 구분선은 어디인가?

- solitary와 sociable의 개념을 알기 전, solitary unit test가 아니면 모두 integration test라고 생각했었는데, 도메인을 쪼개놓은 것을 모킹하지 않고 쓰다보니 unit test이면서 integration 같은 느낌의 테스팅이 되어버림.
- 구분선이 어디인지, 용어를 언제 어떻게 쓰는건지 아직은 헷갈림. 심지어 개개인 마다 정의가 다르다고 느껴짐. 실제로도 모호한 경계선이 존재하는듯.

#### 테스트 describe - it 분기랑 위계 어떻게 어떤 순서로 나누지?

- 내가 여태 듣고 본 것 기준으로 생각해낼 수 있는 건 아래 두 개 인 것 같음:
  1. 아마 bdd가 이런 형식인듯? - 시나리오 기반으로 테스팅 - black box에 가까운 방식인듯함.
  2. 상진님께 배운 - 코드 보면서 분기, 호출 순서 별로 describe it 작성 - white box에 가까운 방식인듯함.
- 두 개 다 장단점이 있는 것 같다. 그래서 꼭 한 쪽이 정답은 아닐 수도 있겠다는 생각을 하고 있다.
- 다만 유닛 테스트에서 더 맞는 것은 무엇인가? 라고 했을 때 음... 유닛 테스트는 white box에 조금 더 가깝기 때문에 분기/호출 별로 describe it을 작성하는 것이 맞을지도 모르겠다는 생각은 들었다.
- 그렇다면 나의 .service.ts 파일에서는 분기별로 할지 vs 시나리오 별로 할지 정해야하는데... 지금 당장 드는 생각은 비즈니스 로직이기에 시나리오 별로 하는게 조금 더 좋지 않을까? 라는 생각이다. 조금 더 알고리즘 적인 유닛 테스트를 할 때 분기 별로 나누면 좋지 않을까... 생각해본다.


#### Policy에 있는 변수들 끌어와서 써야하나? 고정값 그냥 지금처럼 박아야하나?

- policy에 MIN MAX 상수 값들 존재. 이것들을 policy.test에서는 내부적으로 가독성, 재사용성을 위해 사용하되 가장 아래 테스트 케이스에서 이 값들이 바뀌었는지 다시 한 번 검증 함.
- 다만, service.test에서도 policy.test와 동일하게 고정 값들을 변수로 바꿔서 가져와야할지 의문. 예를 들어서

  ```ts
  // 변수
  expect(result).toEqual({
    id: 1,
    point: MAX_ALLOWED_POINT,
    updateMillis: 123456789,
  });

  // 실제 값
  expect(result).toEqual({
    id: 1,
    point: 10_000_000,
    updateMillis: 123456789,
  });
  ```
- Vladimir Khorikov의 Unit test에서는 constant 직접 raw한 숫자로 쓰라고 장려함. 레퍼런스 공유하지 말라고함.
- 하지만 나는 그냥 10_000_000 수십개가 있는 policy.test.ts는 도저히 읽기가 어려워서 변수로 치환하는게 맞다고 생각했고, service의 경우에는 그냥 고정값 쓰는게 맞아보였음. 그래서 지금 상태로 유지 예정.
