### PR TITLE
test: 테스트 위계 & 문구 일관성 리팩토링

### DIFF
--- a/src/common/pipes/parse-positive-int.pipe.spec.ts
+++ b/src/common/pipes/parse-positive-int.pipe.spec.ts
@@ -24,7 +24,7 @@ describe('ParsePositiveIntPipe', () => {
     expect(() => pipe.transform(input)).toThrow('Number exceeds maximum safe integer');
   };
 
-  describe('✅ 정상 입력 - 성공 케이스', () => {
+  describe('transform', () => {
     describe('기본 양의 정수', () => {
       it('"1"을 1로 변환해야 한다', () => {
         expectValidTransform('1', 1);
@@ -49,7 +49,7 @@ describe('ParsePositiveIntPipe', () => {
       });
     });
 
-    describe('경계값 테스트', () => {
+    describe('경계값', () => {
       it('최소 양의 정수 1을 정상 변환해야 한다', () => {
         expectValidTransform('1', 1);
       });
@@ -58,9 +58,7 @@ describe('ParsePositiveIntPipe', () => {
         expectValidTransform('9007199254740991', 9007199254740991); // Number.MAX_SAFE_INTEGER
       });
     });
-  });
 
-  describe('❌ 잘못된 입력 - 에러 케이스', () => {
     describe('0과 음수', () => {
       it('0일 때 BadRequestException을 발생시켜야 한다', () => {
         expectInvalidTransform('0');

--- a/src/point/controller/point.controller.spec.ts
+++ b/src/point/controller/point.controller.spec.ts
@@ -30,7 +30,7 @@ describe('PointController', () => {
   });
 
   describe('GET /point/:id', () => {
-    it('서비스의 getPoint 메서드를 호출하고 결과를 반환함', async () => {
+    it('서비스의 getPoint 메서드를 호출하고 결과를 반환해야 한다', async () => {
       const mockResult = {
         id: 1,
         point: 100,
@@ -43,7 +43,7 @@ describe('PointController', () => {
       expect(result).toEqual(mockResult);
     });
 
-    it('서비스에서 예외가 발생하면 그대로 전파됨', async () => {
+    it('서비스에서 예외가 발생하면 그대로 전파되어야 한다', async () => {
       jest
         .spyOn(pointService, 'getPoint')
         .mockRejectedValue(new InternalServerErrorException());
@@ -53,7 +53,7 @@ describe('PointController', () => {
   });
 
   describe('GET /point/:id/histories', () => {
-    it('서비스의 getHistory 메서드를 호출하고 결과를 반환함', async () => {
+    it('서비스의 getHistory 메서드를 호출하고 결과를 반환해야 한다', async () => {
       const mockResult = [
         {
           id: 1,
@@ -70,7 +70,7 @@ describe('PointController', () => {
       expect(result).toEqual(mockResult);
     });
 
-    it('서비스에서 예외가 발생하면 그대로 전파됨', async () => {
+    it('서비스에서 예외가 발생하면 그대로 전파되어야 한다', async () => {
       jest
         .spyOn(pointService, 'getHistory')
         .mockRejectedValue(new InternalServerErrorException());
@@ -80,7 +80,7 @@ describe('PointController', () => {
   });
 
   describe('PATCH /point/:id/charge', () => {
-    it('서비스의 chargePoint 메서드를 호출하고 결과를 반환함', async () => {
+    it('서비스의 chargePoint 메서드를 호출하고 결과를 반환해야 한다', async () => {
       const mockResult = {
         id: 1,
         point: 200,
@@ -93,7 +93,7 @@ describe('PointController', () => {
       expect(result).toEqual(mockResult);
     });
 
-    it('서비스에서 예외가 발생하면 그대로 전파됨', async () => {
+    it('서비스에서 예외가 발생하면 그대로 전파되어야 한다', async () => {
       jest
         .spyOn(pointService, 'chargePoint')
         .mockRejectedValue(new BadRequestException());
@@ -105,7 +105,7 @@ describe('PointController', () => {
   });
 
   describe('PATCH /point/:id/use', () => {
-    it('서비스의 usePoint 메서드를 호출하고 결과를 반환함', async () => {
+    it('서비스의 usePoint 메서드를 호출하고 결과를 반환해야 한다', async () => {
       const mockResult = {
         id: 1,
         point: 900,
@@ -118,7 +118,7 @@ describe('PointController', () => {
       expect(result).toEqual(mockResult);
     });
 
-    it('서비스에서 예외가 발생하면 그대로 전파됨', async () => {
+    it('서비스에서 예외가 발생하면 그대로 전파되어야 한다', async () => {
       jest.spyOn(pointService, 'usePoint').mockRejectedValue(new BadRequestException());
 
       await expect(controller.use(1, { amount: 100 })).rejects.toThrow(

--- a/src/point/service/point.service.spec.ts
+++ b/src/point/service/point.service.spec.ts
@@ -31,7 +31,7 @@ describe('PointService', () => {
   });
 
   describe('getPoint', () => {
-    it('포인트가 100일 경우 정상적으로 반환됨', async () => {
+    it('포인트가 100일 경우 정상적으로 반환되어야 한다', async () => {
       jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
         id: 1,
         point: 100,
@@ -47,7 +47,7 @@ describe('PointService', () => {
       });
     });
 
-    it('포인트가 0일 경우에도 정상 반환됨', async () => {
+    it('포인트가 0일 경우에도 정상 반환되어야 한다', async () => {
       jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
         id: 1,
         point: 0,
@@ -63,7 +63,7 @@ describe('PointService', () => {
       });
     });
 
-    it('포인트가 최대 허용값(10,000,000)일 때도 정상 반환됨', async () => {
+    it('포인트가 최대 허용값(10,000,000)일 때도 정상 반환되어야 한다', async () => {
       jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
         id: 1,
         point: 10_000_000,
@@ -79,7 +79,7 @@ describe('PointService', () => {
       });
     });
 
-    it('포인트가 음수일 경우 500 에러 발생', async () => {
+    it('포인트가 음수일 경우 500 에러가 발생해야 한다', async () => {
       jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
         id: 1,
         point: -1,
@@ -89,7 +89,7 @@ describe('PointService', () => {
       await expect(service.getPoint(1)).rejects.toThrow(InternalServerErrorException);
     });
 
-    it('포인트가 최대 허용값 초과 시 500 에러 발생', async () => {
+    it('포인트가 최대 허용값 초과 시 500 에러가 발생해야 한다', async () => {
       jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
         id: 1,
         point: 10_000_001,
@@ -99,7 +99,7 @@ describe('PointService', () => {
       await expect(service.getPoint(1)).rejects.toThrow(InternalServerErrorException);
     });
 
-    it('Repository에서 예외가 발생하면 InternalServerError 발생', async () => {
+    it('Repository에서 예외가 발생하면 InternalServerError가 발생해야 한다', async () => {
       jest
         .spyOn(pointRepository, 'getUserPoint')
         .mockRejectedValue(new InternalServerErrorException());
@@ -109,7 +109,7 @@ describe('PointService', () => {
   });
 
   describe('getHistory', () => {
-    it('포인트 내역이 정상적으로 반환됨', async () => {
+    it('포인트 내역이 정상적으로 반환되어야 한다', async () => {
       const mockedPointHistory = {
         id: 1,
         userId: 1,
@@ -124,7 +124,7 @@ describe('PointService', () => {
       expect(result).toEqual([mockedPointHistory]);
     });
 
-    it('포인트 내역이 최신순으로 정렬되어 반환됨', async () => {
+    it('포인트 내역이 최신순으로 정렬되어 반환되어야 한다', async () => {
       const mockedPointHistory1 = {
         id: 1,
         userId: 1,
@@ -148,7 +148,7 @@ describe('PointService', () => {
       expect(result).toEqual([mockedPointHistory2, mockedPointHistory1]);
     });
 
-    it('Repository에서 예외가 발생하면 InternalServerError 발생', async () => {
+    it('Repository에서 예외가 발생하면 InternalServerError가 발생해야 한다', async () => {
       jest
         .spyOn(pointRepository, 'getHistories')
         .mockRejectedValue(new InternalServerErrorException());
@@ -158,7 +158,7 @@ describe('PointService', () => {
   });
 
   describe('chargePoint', () => {
-    it('포인트가 정상적으로 충전됨', async () => {
+    it('포인트가 정상적으로 충전되어야 한다', async () => {
       jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
         id: 1,
         point: 100,
@@ -181,7 +181,7 @@ describe('PointService', () => {
       );
     });
 
-    it('최소 충전 금액이 정상적으로 충전됨', async () => {
+    it('최소 충전 금액이 정상적으로 충전되어야 한다', async () => {
       jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
         id: 1,
         point: 100,
@@ -204,7 +204,7 @@ describe('PointService', () => {
       );
     });
 
-    it('최대 충전 금액이 정상적으로 충전됨', async () => {
+    it('최대 충전 금액이 정상적으로 충전되어야 한다', async () => {
       jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
         id: 1,
         point: 0,
@@ -227,7 +227,7 @@ describe('PointService', () => {
       );
     });
 
-    it('충전 후 총 포인트가 10,000,000P 초과 시 400 에러 발생', async () => {
+    it('충전 후 총 포인트가 10,000,000P 초과 시 400 에러가 발생해야 한다', async () => {
       jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
         id: 1,
         point: 10_000_000,
@@ -237,12 +237,12 @@ describe('PointService', () => {
       await expect(service.chargePoint(1, 1)).rejects.toThrow(BadRequestException);
     });
 
-    it('포인트가 최소 충전 가능 포인트보다 작을 경우 400 에러 발생', async () => {
+    it('포인트가 최소 충전 가능 포인트보다 작을 경우 400 에러가 발생해야 한다', async () => {
       await expect(service.chargePoint(1, -1)).rejects.toThrow(BadRequestException);
       await expect(service.chargePoint(1, 0)).rejects.toThrow(BadRequestException);
     });
 
-    it('Repository에서 예외가 발생하면 InternalServerError 발생', async () => {
+    it('Repository에서 예외가 발생하면 InternalServerError가 발생해야 한다', async () => {
       jest
         .spyOn(pointRepository, 'getUserPoint')
         .mockRejectedValue(new InternalServerErrorException());
@@ -254,7 +254,7 @@ describe('PointService', () => {
   });
 
   describe('usePoint', () => {
-    it('포인트가 정상적으로 사용됨', async () => {
+    it('포인트가 정상적으로 사용되어야 한다', async () => {
       jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
         id: 1,
         point: 1000,
@@ -278,7 +278,7 @@ describe('PointService', () => {
       );
     });
 
-    it('최소 사용 단위(100P) 금액이 정상적으로 사용됨', async () => {
+    it('최소 사용 단위(100P) 금액이 정상적으로 사용되어야 한다', async () => {
       jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
         id: 1,
         point: 100,
@@ -302,7 +302,7 @@ describe('PointService', () => {
       );
     });
 
-    it('최대 사용 금액(10,000P)이 정상적으로 사용됨', async () => {
+    it('최대 사용 금액(10,000P)이 정상적으로 사용되어야 한다', async () => {
       jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
         id: 1,
         point: 5_000_000,
@@ -326,7 +326,7 @@ describe('PointService', () => {
       );
     });
 
-    it('포인트가 최소 사용 단위(100P)보다 작을 경우 400 에러 발생', async () => {
+    it('포인트가 최소 사용 단위(100P)보다 작을 경우 400 에러가 발생해야 한다', async () => {
       jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
         id: 1,
         point: 1000,
@@ -339,7 +339,7 @@ describe('PointService', () => {
       await expect(service.usePoint(1, 101)).rejects.toThrow(BadRequestException);
     });
 
-    it('포인트 사용 후 포인트가 음수가 될 경우 400 에러 발생', async () => {
+    it('포인트 사용 후 포인트가 음수가 될 경우 400 에러가 발생해야 한다', async () => {
       jest.spyOn(pointRepository, 'getHistories').mockResolvedValue([]);
       jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
         id: 1,
@@ -350,7 +350,7 @@ describe('PointService', () => {
       await expect(service.usePoint(1, 200)).rejects.toThrow(BadRequestException);
     });
 
-    it('하루 최대 사용 가능 포인트를 초과할 경우 400 에러 발생', async () => {
+    it('하루 최대 사용 가능 포인트를 초과할 경우 400 에러가 발생해야 한다', async () => {
       jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
         id: 1,
         point: 100000,
@@ -378,7 +378,7 @@ describe('PointService', () => {
       await expect(service.usePoint(1, 100)).rejects.toThrow(BadRequestException);
     });
 
-    it('Repository에서 예외가 발생하면 InternalServerError 발생', async () => {
+    it('Repository에서 예외가 발생하면 InternalServerError가 발생해야 한다', async () => {
       jest
         .spyOn(pointRepository, 'getUserPoint')
         .mockRejectedValue(new InternalServerErrorException());

--- a/src/point/service/point.service.spec.ts
+++ b/src/point/service/point.service.spec.ts
@@ -31,385 +31,361 @@ describe('PointService', () => {
   });
 
   describe('getPoint', () => {
-    describe('😊 정상 작동 (Happy Path & Passing Edge Cases)', () => {
-      it('포인트가 100일 경우 정상적으로 반환됨', async () => {
-        jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
-          id: 1,
-          point: 100,
-          updateMillis: 123456789,
-        });
-
-        const result = await service.getPoint(1);
-
-        expect(result).toEqual({
-          id: 1,
-          point: 100,
-          updateMillis: 123456789,
-        });
+    it('포인트가 100일 경우 정상적으로 반환됨', async () => {
+      jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
+        id: 1,
+        point: 100,
+        updateMillis: 123456789,
       });
 
-      it('포인트가 0일 경우에도 정상 반환됨', async () => {
-        jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
-          id: 1,
-          point: 0,
-          updateMillis: 123456789,
-        });
+      const result = await service.getPoint(1);
 
-        const result = await service.getPoint(1);
-
-        expect(result).toEqual({
-          id: 1,
-          point: 0,
-          updateMillis: 123456789,
-        });
-      });
-
-      it('포인트가 최대 허용값(10,000,000)일 때도 정상 반환됨', async () => {
-        jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
-          id: 1,
-          point: 10_000_000,
-          updateMillis: 123456789,
-        });
-
-        const result = await service.getPoint(1);
-
-        expect(result).toEqual({
-          id: 1,
-          point: 10_000_000,
-          updateMillis: 123456789,
-        });
+      expect(result).toEqual({
+        id: 1,
+        point: 100,
+        updateMillis: 123456789,
       });
     });
 
-    describe('💼 정책 예외 (Business Rule Violation)', () => {
-      it('포인트가 음수일 경우 500 에러 발생', async () => {
-        jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
-          id: 1,
-          point: -1,
-          updateMillis: 123456789,
-        });
-
-        await expect(service.getPoint(1)).rejects.toThrow(InternalServerErrorException);
+    it('포인트가 0일 경우에도 정상 반환됨', async () => {
+      jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
+        id: 1,
+        point: 0,
+        updateMillis: 123456789,
       });
 
-      it('포인트가 최대 허용값 초과 시 500 에러 발생', async () => {
-        jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
-          id: 1,
-          point: 10_000_001,
-          updateMillis: 123456789,
-        });
+      const result = await service.getPoint(1);
 
-        await expect(service.getPoint(1)).rejects.toThrow(InternalServerErrorException);
+      expect(result).toEqual({
+        id: 1,
+        point: 0,
+        updateMillis: 123456789,
       });
     });
 
-    describe('💥 시스템 예외 (Unexpected Errors)', () => {
-      it('Repository에서 예외가 발생하면 InternalServerError 발생', async () => {
-        jest
-          .spyOn(pointRepository, 'getUserPoint')
-          .mockRejectedValue(new InternalServerErrorException());
-
-        await expect(service.getPoint(1)).rejects.toThrow(InternalServerErrorException);
+    it('포인트가 최대 허용값(10,000,000)일 때도 정상 반환됨', async () => {
+      jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
+        id: 1,
+        point: 10_000_000,
+        updateMillis: 123456789,
       });
+
+      const result = await service.getPoint(1);
+
+      expect(result).toEqual({
+        id: 1,
+        point: 10_000_000,
+        updateMillis: 123456789,
+      });
+    });
+
+    it('포인트가 음수일 경우 500 에러 발생', async () => {
+      jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
+        id: 1,
+        point: -1,
+        updateMillis: 123456789,
+      });
+
+      await expect(service.getPoint(1)).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('포인트가 최대 허용값 초과 시 500 에러 발생', async () => {
+      jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
+        id: 1,
+        point: 10_000_001,
+        updateMillis: 123456789,
+      });
+
+      await expect(service.getPoint(1)).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('Repository에서 예외가 발생하면 InternalServerError 발생', async () => {
+      jest
+        .spyOn(pointRepository, 'getUserPoint')
+        .mockRejectedValue(new InternalServerErrorException());
+
+      await expect(service.getPoint(1)).rejects.toThrow(InternalServerErrorException);
     });
   });
 
   describe('getHistory', () => {
-    describe('😊 정상 작동 (Happy Path & Passing Edge Cases)', () => {
-      it('포인트 내역이 정상적으로 반환됨', async () => {
-        const mockedPointHistory = {
-          id: 1,
-          userId: 1,
-          amount: 100,
-          type: TransactionType.CHARGE,
-          timeMillis: 123456789,
-        };
-        jest
-          .spyOn(pointRepository, 'getHistories')
-          .mockResolvedValue([mockedPointHistory]);
+    it('포인트 내역이 정상적으로 반환됨', async () => {
+      const mockedPointHistory = {
+        id: 1,
+        userId: 1,
+        amount: 100,
+        type: TransactionType.CHARGE,
+        timeMillis: 123456789,
+      };
+      jest.spyOn(pointRepository, 'getHistories').mockResolvedValue([mockedPointHistory]);
 
-        const result = await service.getHistory(1);
+      const result = await service.getHistory(1);
 
-        expect(result).toEqual([mockedPointHistory]);
-      });
-
-      it('포인트 내역이 최신순으로 정렬되어 반환됨', async () => {
-        const mockedPointHistory1 = {
-          id: 1,
-          userId: 1,
-          amount: 100,
-          type: TransactionType.CHARGE,
-          timeMillis: 123456788,
-        };
-        const mockedPointHistory2 = {
-          id: 2,
-          userId: 1,
-          amount: 100,
-          type: TransactionType.CHARGE,
-          timeMillis: 123456789,
-        };
-        jest
-          .spyOn(pointRepository, 'getHistories')
-          .mockResolvedValue([mockedPointHistory1, mockedPointHistory2]);
-
-        const result = await service.getHistory(1);
-
-        expect(result).toEqual([mockedPointHistory2, mockedPointHistory1]);
-      });
+      expect(result).toEqual([mockedPointHistory]);
     });
 
-    describe('💥 시스템 예외 (Unexpected Errors)', () => {
-      it('Repository에서 예외가 발생하면 InternalServerError 발생', async () => {
-        jest
-          .spyOn(pointRepository, 'getHistories')
-          .mockRejectedValue(new InternalServerErrorException());
+    it('포인트 내역이 최신순으로 정렬되어 반환됨', async () => {
+      const mockedPointHistory1 = {
+        id: 1,
+        userId: 1,
+        amount: 100,
+        type: TransactionType.CHARGE,
+        timeMillis: 123456788,
+      };
+      const mockedPointHistory2 = {
+        id: 2,
+        userId: 1,
+        amount: 100,
+        type: TransactionType.CHARGE,
+        timeMillis: 123456789,
+      };
+      jest
+        .spyOn(pointRepository, 'getHistories')
+        .mockResolvedValue([mockedPointHistory1, mockedPointHistory2]);
 
-        await expect(service.getHistory(1)).rejects.toThrow(InternalServerErrorException);
-      });
+      const result = await service.getHistory(1);
+
+      expect(result).toEqual([mockedPointHistory2, mockedPointHistory1]);
+    });
+
+    it('Repository에서 예외가 발생하면 InternalServerError 발생', async () => {
+      jest
+        .spyOn(pointRepository, 'getHistories')
+        .mockRejectedValue(new InternalServerErrorException());
+
+      await expect(service.getHistory(1)).rejects.toThrow(InternalServerErrorException);
     });
   });
 
   describe('chargePoint', () => {
-    describe('😊 정상 작동 (Happy Path & Passing Edge Cases)', () => {
-      it('포인트가 정상적으로 충전됨', async () => {
-        jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
-          id: 1,
-          point: 100,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(pointRepository, 'updatePointWithHistory').mockResolvedValue({
-          id: 1,
-          point: 200,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(Date, 'now').mockReturnValue(123456789);
-
-        await service.chargePoint(1, 100);
-
-        expect(pointRepository.updatePointWithHistory).toHaveBeenCalledWith(
-          1,
-          200,
-          100,
-          TransactionType.CHARGE,
-        );
+    it('포인트가 정상적으로 충전됨', async () => {
+      jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
+        id: 1,
+        point: 100,
+        updateMillis: 123456789,
       });
-
-      it('최소 충전 금액이 정상적으로 충전됨', async () => {
-        jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
-          id: 1,
-          point: 100,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(pointRepository, 'updatePointWithHistory').mockResolvedValue({
-          id: 1,
-          point: 101,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(Date, 'now').mockReturnValue(123456789);
-
-        await service.chargePoint(1, 1);
-
-        expect(pointRepository.updatePointWithHistory).toHaveBeenCalledWith(
-          1,
-          101,
-          1,
-          TransactionType.CHARGE,
-        );
+      jest.spyOn(pointRepository, 'updatePointWithHistory').mockResolvedValue({
+        id: 1,
+        point: 200,
+        updateMillis: 123456789,
       });
+      jest.spyOn(Date, 'now').mockReturnValue(123456789);
 
-      it('최대 충전 금액이 정상적으로 충전됨', async () => {
-        jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
-          id: 1,
-          point: 0,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(pointRepository, 'updatePointWithHistory').mockResolvedValue({
-          id: 1,
-          point: 10_000_000,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(Date, 'now').mockReturnValue(123456789);
+      await service.chargePoint(1, 100);
 
-        await service.chargePoint(1, 10_000_000);
-
-        expect(pointRepository.updatePointWithHistory).toHaveBeenCalledWith(
-          1,
-          10_000_000,
-          10_000_000,
-          TransactionType.CHARGE,
-        );
-      });
+      expect(pointRepository.updatePointWithHistory).toHaveBeenCalledWith(
+        1,
+        200,
+        100,
+        TransactionType.CHARGE,
+      );
     });
 
-    describe('💼 정책 예외 (Business Rule Violation)', () => {
-      it('충전 후 총 포인트가 10,000,000P 초과 시 400 에러 발생', async () => {
-        jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
-          id: 1,
-          point: 10_000_000,
-          updateMillis: 123456789,
-        });
-
-        await expect(service.chargePoint(1, 1)).rejects.toThrow(BadRequestException);
+    it('최소 충전 금액이 정상적으로 충전됨', async () => {
+      jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
+        id: 1,
+        point: 100,
+        updateMillis: 123456789,
       });
-
-      it('포인트가 최소 충전 가능 포인트보다 작을 경우 400 에러 발생', async () => {
-        await expect(service.chargePoint(1, -1)).rejects.toThrow(BadRequestException);
-        await expect(service.chargePoint(1, 0)).rejects.toThrow(BadRequestException);
+      jest.spyOn(pointRepository, 'updatePointWithHistory').mockResolvedValue({
+        id: 1,
+        point: 101,
+        updateMillis: 123456789,
       });
+      jest.spyOn(Date, 'now').mockReturnValue(123456789);
+
+      await service.chargePoint(1, 1);
+
+      expect(pointRepository.updatePointWithHistory).toHaveBeenCalledWith(
+        1,
+        101,
+        1,
+        TransactionType.CHARGE,
+      );
     });
 
-    describe('💥 시스템 예외 (Unexpected Errors)', () => {
-      it('Repository에서 예외가 발생하면 InternalServerError 발생', async () => {
-        jest
-          .spyOn(pointRepository, 'getUserPoint')
-          .mockRejectedValue(new InternalServerErrorException());
-
-        await expect(service.chargePoint(1, 100)).rejects.toThrow(
-          InternalServerErrorException,
-        );
+    it('최대 충전 금액이 정상적으로 충전됨', async () => {
+      jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
+        id: 1,
+        point: 0,
+        updateMillis: 123456789,
       });
+      jest.spyOn(pointRepository, 'updatePointWithHistory').mockResolvedValue({
+        id: 1,
+        point: 10_000_000,
+        updateMillis: 123456789,
+      });
+      jest.spyOn(Date, 'now').mockReturnValue(123456789);
+
+      await service.chargePoint(1, 10_000_000);
+
+      expect(pointRepository.updatePointWithHistory).toHaveBeenCalledWith(
+        1,
+        10_000_000,
+        10_000_000,
+        TransactionType.CHARGE,
+      );
+    });
+
+    it('충전 후 총 포인트가 10,000,000P 초과 시 400 에러 발생', async () => {
+      jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
+        id: 1,
+        point: 10_000_000,
+        updateMillis: 123456789,
+      });
+
+      await expect(service.chargePoint(1, 1)).rejects.toThrow(BadRequestException);
+    });
+
+    it('포인트가 최소 충전 가능 포인트보다 작을 경우 400 에러 발생', async () => {
+      await expect(service.chargePoint(1, -1)).rejects.toThrow(BadRequestException);
+      await expect(service.chargePoint(1, 0)).rejects.toThrow(BadRequestException);
+    });
+
+    it('Repository에서 예외가 발생하면 InternalServerError 발생', async () => {
+      jest
+        .spyOn(pointRepository, 'getUserPoint')
+        .mockRejectedValue(new InternalServerErrorException());
+
+      await expect(service.chargePoint(1, 100)).rejects.toThrow(
+        InternalServerErrorException,
+      );
     });
   });
 
   describe('usePoint', () => {
-    describe('😊 정상 작동 (Happy Path & Passing Edge Cases)', () => {
-      it('포인트가 정상적으로 사용됨', async () => {
-        jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
-          id: 1,
-          point: 1000,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(pointRepository, 'getHistories').mockResolvedValue([]);
-        jest.spyOn(pointRepository, 'updatePointWithHistory').mockResolvedValue({
-          id: 1,
-          point: 900,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(Date, 'now').mockReturnValue(123456789);
-
-        await service.usePoint(1, 100);
-
-        expect(pointRepository.updatePointWithHistory).toHaveBeenCalledWith(
-          1,
-          900,
-          100,
-          TransactionType.USE,
-        );
+    it('포인트가 정상적으로 사용됨', async () => {
+      jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
+        id: 1,
+        point: 1000,
+        updateMillis: 123456789,
       });
-
-      it('최소 사용 단위(100P) 금액이 정상적으로 사용됨', async () => {
-        jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
-          id: 1,
-          point: 100,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(pointRepository, 'getHistories').mockResolvedValue([]);
-        jest.spyOn(pointRepository, 'updatePointWithHistory').mockResolvedValue({
-          id: 1,
-          point: 0,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(Date, 'now').mockReturnValue(123456789);
-
-        await service.usePoint(1, 100);
-
-        expect(pointRepository.updatePointWithHistory).toHaveBeenCalledWith(
-          1,
-          0,
-          100,
-          TransactionType.USE,
-        );
+      jest.spyOn(pointRepository, 'getHistories').mockResolvedValue([]);
+      jest.spyOn(pointRepository, 'updatePointWithHistory').mockResolvedValue({
+        id: 1,
+        point: 900,
+        updateMillis: 123456789,
       });
+      jest.spyOn(Date, 'now').mockReturnValue(123456789);
 
-      it('최대 사용 금액(10,000P)이 정상적으로 사용됨', async () => {
-        jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
-          id: 1,
-          point: 5_000_000,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(pointRepository, 'getHistories').mockResolvedValue([]);
-        jest.spyOn(pointRepository, 'updatePointWithHistory').mockResolvedValue({
-          id: 1,
-          point: 4_990_000,
-          updateMillis: 123456789,
-        });
-        jest.spyOn(Date, 'now').mockReturnValue(123456789);
+      await service.usePoint(1, 100);
 
-        await service.usePoint(1, 10_000);
-
-        expect(pointRepository.updatePointWithHistory).toHaveBeenCalledWith(
-          1,
-          4_990_000,
-          10_000,
-          TransactionType.USE,
-        );
-      });
+      expect(pointRepository.updatePointWithHistory).toHaveBeenCalledWith(
+        1,
+        900,
+        100,
+        TransactionType.USE,
+      );
     });
 
-    describe('💼 정책 예외 (Business Rule Violation)', () => {
-      it('포인트가 최소 사용 단위(100P)보다 작을 경우 400 에러 발생', async () => {
-        jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
-          id: 1,
-          point: 1000,
-          updateMillis: 123456789,
-        });
-
-        await expect(service.usePoint(1, 99)).rejects.toThrow(BadRequestException);
-        await expect(service.usePoint(1, 0)).rejects.toThrow(BadRequestException);
-        await expect(service.usePoint(1, -1)).rejects.toThrow(BadRequestException);
-        await expect(service.usePoint(1, 101)).rejects.toThrow(BadRequestException);
+    it('최소 사용 단위(100P) 금액이 정상적으로 사용됨', async () => {
+      jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
+        id: 1,
+        point: 100,
+        updateMillis: 123456789,
       });
-
-      it('포인트 사용 후 포인트가 음수가 될 경우 400 에러 발생', async () => {
-        jest.spyOn(pointRepository, 'getHistories').mockResolvedValue([]);
-        jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
-          id: 1,
-          point: 100,
-          updateMillis: 123456789,
-        });
-
-        await expect(service.usePoint(1, 200)).rejects.toThrow(BadRequestException);
+      jest.spyOn(pointRepository, 'getHistories').mockResolvedValue([]);
+      jest.spyOn(pointRepository, 'updatePointWithHistory').mockResolvedValue({
+        id: 1,
+        point: 0,
+        updateMillis: 123456789,
       });
+      jest.spyOn(Date, 'now').mockReturnValue(123456789);
 
-      it('하루 최대 사용 가능 포인트를 초과할 경우 400 에러 발생', async () => {
-        jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
-          id: 1,
-          point: 100000,
-          updateMillis: 123456789,
-        });
+      await service.usePoint(1, 100);
 
-        jest.spyOn(pointRepository, 'getHistories').mockResolvedValue([
-          {
-            id: 1,
-            userId: 1,
-            amount: 30000,
-            type: TransactionType.USE,
-            timeMillis: Date.now(),
-          },
-          {
-            id: 2,
-            userId: 1,
-            amount: 20000,
-            type: TransactionType.USE,
-            timeMillis: Date.now(),
-          },
-        ]);
-
-        // 이미 50000P를 사용했으므로 추가 사용 불가
-        await expect(service.usePoint(1, 100)).rejects.toThrow(BadRequestException);
-      });
+      expect(pointRepository.updatePointWithHistory).toHaveBeenCalledWith(
+        1,
+        0,
+        100,
+        TransactionType.USE,
+      );
     });
 
-    describe('💥 시스템 예외 (Unexpected Errors)', () => {
-      it('Repository에서 예외가 발생하면 InternalServerError 발생', async () => {
-        jest
-          .spyOn(pointRepository, 'getUserPoint')
-          .mockRejectedValue(new InternalServerErrorException());
-
-        await expect(service.usePoint(1, 100)).rejects.toThrow(
-          InternalServerErrorException,
-        );
+    it('최대 사용 금액(10,000P)이 정상적으로 사용됨', async () => {
+      jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
+        id: 1,
+        point: 5_000_000,
+        updateMillis: 123456789,
       });
+      jest.spyOn(pointRepository, 'getHistories').mockResolvedValue([]);
+      jest.spyOn(pointRepository, 'updatePointWithHistory').mockResolvedValue({
+        id: 1,
+        point: 4_990_000,
+        updateMillis: 123456789,
+      });
+      jest.spyOn(Date, 'now').mockReturnValue(123456789);
+
+      await service.usePoint(1, 10_000);
+
+      expect(pointRepository.updatePointWithHistory).toHaveBeenCalledWith(
+        1,
+        4_990_000,
+        10_000,
+        TransactionType.USE,
+      );
+    });
+
+    it('포인트가 최소 사용 단위(100P)보다 작을 경우 400 에러 발생', async () => {
+      jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
+        id: 1,
+        point: 1000,
+        updateMillis: 123456789,
+      });
+
+      await expect(service.usePoint(1, 99)).rejects.toThrow(BadRequestException);
+      await expect(service.usePoint(1, 0)).rejects.toThrow(BadRequestException);
+      await expect(service.usePoint(1, -1)).rejects.toThrow(BadRequestException);
+      await expect(service.usePoint(1, 101)).rejects.toThrow(BadRequestException);
+    });
+
+    it('포인트 사용 후 포인트가 음수가 될 경우 400 에러 발생', async () => {
+      jest.spyOn(pointRepository, 'getHistories').mockResolvedValue([]);
+      jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
+        id: 1,
+        point: 100,
+        updateMillis: 123456789,
+      });
+
+      await expect(service.usePoint(1, 200)).rejects.toThrow(BadRequestException);
+    });
+
+    it('하루 최대 사용 가능 포인트를 초과할 경우 400 에러 발생', async () => {
+      jest.spyOn(pointRepository, 'getUserPoint').mockResolvedValue({
+        id: 1,
+        point: 100000,
+        updateMillis: 123456789,
+      });
+
+      jest.spyOn(pointRepository, 'getHistories').mockResolvedValue([
+        {
+          id: 1,
+          userId: 1,
+          amount: 30000,
+          type: TransactionType.USE,
+          timeMillis: Date.now(),
+        },
+        {
+          id: 2,
+          userId: 1,
+          amount: 20000,
+          type: TransactionType.USE,
+          timeMillis: Date.now(),
+        },
+      ]);
+
+      // 이미 50000P를 사용했으므로 추가 사용 불가
+      await expect(service.usePoint(1, 100)).rejects.toThrow(BadRequestException);
+    });
+
+    it('Repository에서 예외가 발생하면 InternalServerError 발생', async () => {
+      jest
+        .spyOn(pointRepository, 'getUserPoint')
+        .mockRejectedValue(new InternalServerErrorException());
+
+      await expect(service.usePoint(1, 100)).rejects.toThrow(
+        InternalServerErrorException,
+      );
     });
   });
 });

--- a/src/point/service/policy/point.policy.spec.ts
+++ b/src/point/service/policy/point.policy.spec.ts
@@ -14,7 +14,7 @@ describe('PointPolicy', () => {
   });
 
   describe('checkPointRange', () => {
-    it('포인트가 유효한 범위(0 이상)일 때 성공해야 한다', () => {
+    it('포인트가 유효한 범위(0 이상, 최대값 이하)일 때 성공해야 한다', () => {
       expect(() => pointPolicy.checkPointRange(0)).not.toThrow();
       expect(() => pointPolicy.checkPointRange(1000)).not.toThrow();
       expect(() =>
@@ -229,18 +229,18 @@ describe('PointPolicy', () => {
   });
 
   describe('상수 값 검증', () => {
+    // 이 테스트는 상수 값이 변경되었을 때 알 수 있도록 하는 안전장치입니다
     it('정의된 상수들이 올바른 값을 가져야 한다', () => {
-      // 이 테스트는 상수 값이 변경되었을 때 알 수 있도록 하는 안전장치입니다
       expect(() => pointPolicy.checkPointRange(10_000_000)).not.toThrow();
-      expect(() => pointPolicy.checkPointRange(10_000_000 + 1)).toThrow();
-
       expect(() => pointPolicy.checkDailyUseLimit(0, 50_000)).not.toThrow();
-      expect(() => pointPolicy.checkDailyUseLimit(0, 50_000 + 1)).toThrow();
-
       expect(() => pointPolicy.checkUseAmount(100)).not.toThrow();
-      expect(() => pointPolicy.checkUseAmount(100 - 1)).toThrow();
-
       expect(() => pointPolicy.checkUseAmount(200)).not.toThrow();
+    });
+
+    it('상수 경계값을 벗어나면 예외가 발생해야 한다', () => {
+      expect(() => pointPolicy.checkPointRange(10_000_000 + 1)).toThrow();
+      expect(() => pointPolicy.checkDailyUseLimit(0, 50_000 + 1)).toThrow();
+      expect(() => pointPolicy.checkUseAmount(100 - 1)).toThrow();
       expect(() => pointPolicy.checkUseAmount(200 + 50)).toThrow();
     });
   });


### PR DESCRIPTION
### 💬 배경

- describe it의 위계에 이슈가 있었습니다. 해당 PR전에는 1안 2안 각 레이어마다는 통일되어있는데 프로젝트 전체로 보면 일관성이 없이 섞여있었습니다. 1안의 경우 한 번 더 보기 좋게 묶어주었는데 이렇게 묶어줄 경우 오히려 불필요하게 가독성이 저하된다고 느꼈습니다.
- 그래서 2안으로 진행 뒤에 각 It의 순서는 SUT 대상 함수 내에서의 관련 호출 순서와 대체로 유사하게 진행하는 것을 목표로 잡았습니다.

1안
```ts
describe('getPoint')
  describe('성공 케이스')
    it('포인트가 정상 조회된다.')
  describe('실패/예외 케이스')
    it('레포지토리에서 예외가 반환되면 예외를 그대로 전파한다')
```

2안
```ts
describe('getPoint')
    it('포인트가 정상 조회된다.')
    it('레포지토리에서 예외가 반환되면 예외를 그대로 전파한다')
```

### 📚 커밋 로그

- 테스트 위계 일관성 리팩토링: [ce8b0e9](https://github.com/seho0808/hh-9-be/pull/13/commits/ce8b0e914c4d627cdc6a477678830cae1ed5d11b)
- point policy 마이너 리팩토링: [7317ae](https://github.com/seho0808/hh-9-be/pull/13/commits/7317aea51d8df8f442b139be149902a850a60427)
- 테스트 문구 일관성 리팩토링: [c5e5a10](https://github.com/seho0808/hh-9-be/pull/13/commits/c5e5a1046d406e2b857ee182e1ab7acd6bc35a2e)

### 🤔 고민 포인트


#### 테스트 위계 정하기가 꽤 어렵다! 고민 끝에 정하게 됨. ([48dfa65](https://github.com/seho0808/hh-9-be/pull/13/commits/48dfa652e098ccd59a73d499e8bf3461414c5733))
- describe, it 사이에 정상 케이스, 비정상 케이스 묶어주는 단위가 있었음.
- 일관성을 위해 해당 커밋 작업할 때 처음에는 모든 테스트에 이걸 적용했다가 오히려 다 빼는 게 깔끔해보여서 모두 제거
- 모두 제거하고나니 자연스럽게 유닛 테스팅하는 함수 내부에서의 라인바이라인 로직 순서에 따라서 it들의 순서가 결정되는게 맞아보임.
- 다만 이는 white box testing에 조금 더 가깝기에 과도하게 함수 내부 구현에 의존하지 않게 조심해야함.
