### PR TITLE
refactor: Exception 글로벌에서 한 번에 핸들링

### DIFF
--- a/src/common/exceptions/business.exception.ts
+++ b/src/common/exceptions/business.exception.ts
@@ -1,0 +1,44 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class BusinessException extends HttpException {
+  constructor(message: string) {
+    super(
+      {
+        statusCode: HttpStatus.BAD_REQUEST,
+        error: 'Business Logic Error',
+        message,
+      },
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+}
+
+export class InvalidChargeAmountException extends BusinessException {
+  constructor() {
+    super('충전 금액이 유효하지 않습니다.');
+  }
+}
+
+export class PointLimitExceededException extends BusinessException {
+  constructor() {
+    super('포인트 한도 초과');
+  }
+}
+
+export class InvalidUseAmountException extends BusinessException {
+  constructor() {
+    super('포인트 사용 단위 오류');
+  }
+}
+
+export class DailyUseLimitExceededException extends BusinessException {
+  constructor() {
+    super('일일 사용 한도 초과');
+  }
+}
+
+export class InsufficientBalanceException extends BusinessException {
+  constructor() {
+    super('잔액 부족');
+  }
+}

--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -1,0 +1,10 @@
+export { ValidationException } from './validation.exception';
+export {
+  BusinessException,
+  InvalidChargeAmountException,
+  PointLimitExceededException,
+  InvalidUseAmountException,
+  DailyUseLimitExceededException,
+  InsufficientBalanceException,
+} from './business.exception';
+export { SystemException, InvalidPointRangeException } from './system.exception';

--- a/src/common/exceptions/system.exception.ts
+++ b/src/common/exceptions/system.exception.ts
@@ -1,0 +1,20 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class SystemException extends HttpException {
+  constructor(message: string = '시스템 내부 오류가 발생했습니다.') {
+    super(
+      {
+        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+        error: 'Internal System Error',
+        message,
+      },
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+}
+
+export class InvalidPointRangeException extends SystemException {
+  constructor() {
+    super('비정상 포인트 범위');
+  }
+}

--- a/src/common/exceptions/validation.exception.ts
+++ b/src/common/exceptions/validation.exception.ts
@@ -1,0 +1,14 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class ValidationException extends HttpException {
+  constructor(message: string) {
+    super(
+      {
+        statusCode: HttpStatus.BAD_REQUEST,
+        error: 'Validation Error',
+        message,
+      },
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+}

--- a/src/common/filters/global-exception.filter.ts
+++ b/src/common/filters/global-exception.filter.ts
@@ -1,0 +1,37 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  Logger,
+  HttpException,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { ValidationException, BusinessException, SystemException } from '../exceptions';
+
+@Catch(ValidationException, BusinessException, SystemException)
+export class GlobalExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(GlobalExceptionFilter.name);
+
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const status = exception.getStatus();
+    const exceptionResponse = exception.getResponse() as object;
+
+    // 로그 레벨을 예외 타입에 따라 결정
+    if (exception instanceof SystemException) {
+      this.logger.error(`System error: ${JSON.stringify(exceptionResponse)}`);
+    } else if (exception instanceof BusinessException) {
+      this.logger.warn(`Business logic error: ${JSON.stringify(exceptionResponse)}`);
+    } else if (exception instanceof ValidationException) {
+      this.logger.warn(`Validation error: ${JSON.stringify(exceptionResponse)}`);
+    } else {
+      this.logger.error(`Unknown error: ${JSON.stringify(exceptionResponse)}`);
+    }
+
+    response.status(status).json({
+      timestamp: new Date().toISOString(),
+      ...exceptionResponse,
+    });
+  }
+}

--- a/src/common/pipes/parse-positive-int.pipe.spec.ts
+++ b/src/common/pipes/parse-positive-int.pipe.spec.ts
@@ -1,5 +1,5 @@
-import { BadRequestException } from '@nestjs/common';
 import { ParsePositiveIntPipe } from './parse-positive-int.pipe';
+import { ValidationException } from '../exceptions';
 
 describe('ParsePositiveIntPipe', () => {
   let pipe: ParsePositiveIntPipe;
@@ -15,12 +15,12 @@ describe('ParsePositiveIntPipe', () => {
   };
 
   const expectInvalidTransform = (input: string) => {
-    expect(() => pipe.transform(input)).toThrow(BadRequestException);
+    expect(() => pipe.transform(input)).toThrow(ValidationException);
     expect(() => pipe.transform(input)).toThrow('Only positive integers are allowed');
   };
 
   const expectMaxSafeIntegerExceededError = (input: string) => {
-    expect(() => pipe.transform(input)).toThrow(BadRequestException);
+    expect(() => pipe.transform(input)).toThrow(ValidationException);
     expect(() => pipe.transform(input)).toThrow('Number exceeds maximum safe integer');
   };
 

--- a/src/common/pipes/parse-positive-int.pipe.ts
+++ b/src/common/pipes/parse-positive-int.pipe.ts
@@ -1,4 +1,5 @@
-import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
+import { PipeTransform, Injectable } from '@nestjs/common';
+import { ValidationException } from '../exceptions';
 
 @Injectable()
 export class ParsePositiveIntPipe implements PipeTransform {
@@ -8,13 +9,13 @@ export class ParsePositiveIntPipe implements PipeTransform {
     const positiveIntegerRegex = /^(\+)?[1-9]\d*$/;
 
     if (!positiveIntegerRegex.test(trimmedValue)) {
-      throw new BadRequestException('Only positive integers are allowed');
+      throw new ValidationException('Only positive integers are allowed');
     }
 
     const parsed = Number(trimmedValue);
 
     if (parsed > Number.MAX_SAFE_INTEGER) {
-      throw new BadRequestException('Number exceeds maximum safe integer');
+      throw new ValidationException('Number exceeds maximum safe integer');
     }
 
     return parsed;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { GlobalExceptionFilter } from './common/filters/global-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // 글로벌 예외 필터 등록
+  app.useGlobalFilters(new GlobalExceptionFilter());
+
   await app.listen(3000);
 }
 bootstrap();

--- a/src/point/point.repository.ts
+++ b/src/point/point.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { SystemException } from 'src/common/exceptions';
 import { PointHistory, TransactionType, UserPoint } from './point.model';
 import { UserPointTable } from 'src/database/userpoint.table';
 import { PointHistoryTable } from 'src/database/pointhistory.table';
@@ -14,7 +15,7 @@ export class PointRepository {
     try {
       return await this.userDb.selectById(id);
     } catch (error) {
-      throw new InternalServerErrorException();
+      throw new SystemException();
     }
   }
 
@@ -22,7 +23,7 @@ export class PointRepository {
     try {
       return await this.historyDb.selectAllByUserId(id);
     } catch (error) {
-      throw new InternalServerErrorException();
+      throw new SystemException();
     }
   }
 
@@ -37,7 +38,7 @@ export class PointRepository {
       await this.historyDb.insert(id, amount, type, Date.now());
       return updatedPoint;
     } catch (error) {
-      throw new InternalServerErrorException();
+      throw new SystemException();
     }
   }
 }

--- a/src/point/service/policy/point.policy.ts
+++ b/src/point/service/policy/point.policy.ts
@@ -1,8 +1,12 @@
+import { Injectable } from '@nestjs/common';
 import {
-  BadRequestException,
-  Injectable,
-  InternalServerErrorException,
-} from '@nestjs/common';
+  InvalidChargeAmountException,
+  PointLimitExceededException,
+  InvalidUseAmountException,
+  DailyUseLimitExceededException,
+  InsufficientBalanceException,
+  InvalidPointRangeException,
+} from 'src/common/exceptions';
 
 @Injectable()
 export class PointPolicy {
@@ -13,19 +17,19 @@ export class PointPolicy {
 
   checkPointRange(point: number): void {
     if (point < 0 || point > PointPolicy.MAX_POINT_LIMIT) {
-      throw new InternalServerErrorException('비정상 포인트 범위');
+      throw new InvalidPointRangeException();
     }
   }
 
   checkChargeAmount(amount: number): void {
     if (amount < 1 || amount > PointPolicy.MAX_POINT_LIMIT) {
-      throw new BadRequestException('충전 금액이 유효하지 않습니다.');
+      throw new InvalidChargeAmountException();
     }
   }
 
   checkChargeLimit(currentPoint: number, amount: number): void {
     if (currentPoint + amount > PointPolicy.MAX_POINT_LIMIT) {
-      throw new BadRequestException('포인트 한도 초과');
+      throw new PointLimitExceededException();
     }
   }
 
@@ -35,19 +39,19 @@ export class PointPolicy {
       amount > PointPolicy.MAX_POINT_LIMIT ||
       amount % PointPolicy.USE_AMOUNT_UNIT !== 0
     ) {
-      throw new BadRequestException('포인트 사용 단위 오류');
+      throw new InvalidUseAmountException();
     }
   }
 
   checkDailyUseLimit(pointsUsedToday: number, amount: number): void {
     if (pointsUsedToday + amount > PointPolicy.DAILY_USE_LIMIT) {
-      throw new BadRequestException('일일 사용 한도 초과');
+      throw new DailyUseLimitExceededException();
     }
   }
 
   checkSufficientBalance(currentPoint: number, amount: number): void {
     if (currentPoint < amount) {
-      throw new BadRequestException('잔액 부족');
+      throw new InsufficientBalanceException();
     }
   }
 }


### PR DESCRIPTION
### 💬 배경

- nest js에서는 정의된 nest 전용 에러 객체를 자동으로 http 코드에 맞게 변환합니다.
- 이에 모든 레이어에서 http 에러를 throw하는 듯한 느낌을 받았습니다.
- 각 클래스나 함수 내에서 본인들의 역할에 충실할 수록 돕기 위해 글로벌 Exception filter와 세부 예외 타입들을 정의했습니다.

### 📚 커밋 로그

- 신규 exception 정의: [e2f1943](https://github.com/seho0808/hh-9-be/pull/15/commits/e2f1943fb8effe61009b3058261f2442c8e79bf1)
- 신규 exception filter 구현: [10202d7](https://github.com/seho0808/hh-9-be/pull/15/commits/10202d7f46bbdc81eaf335a8a1d2e5293ba07e82)
- 전체 프로젝트 리팩토링: [90657fe](https://github.com/seho0808/hh-9-be/pull/15/commits/90657fef7f2984836dcbb00b6f2a6d5cf3443bc9)